### PR TITLE
Fix port change in admin panel

### DIFF
--- a/model/server.go
+++ b/model/server.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"encoding/json"
+	"strconv"
 	"time"
 )
 
@@ -20,12 +22,54 @@ type ServerKeypair struct {
 // ServerInterface model
 type ServerInterface struct {
 	Addresses  []string  `json:"addresses"`
-	ListenPort int       `json:"listen_port,string"` // ,string to get listen_port string input as int
+	ListenPort int       `json:"listen_port"`
 	UpdatedAt  time.Time `json:"updated_at"`
 	PostUp     string    `json:"post_up"`
 	PreDown    string    `json:"pre_down"`
 	PostDown   string    `json:"post_down"`
-	    // فیلد جدید برای فاصله بررسی (بر حسب دقیقه)
-		CheckInterval int    `json:"check_interval"`
+	// فیلد جدید برای فاصله بررسی (بر حسب دقیقه)
+	CheckInterval int `json:"check_interval"`
+}
+
+// UnmarshalJSON implements custom decoding to allow listen_port and check_interval
+// to be provided as either strings or numbers.
+func (s *ServerInterface) UnmarshalJSON(data []byte) error {
+	type Alias ServerInterface
+	aux := &struct {
+		ListenPort    any `json:"listen_port"`
+		CheckInterval any `json:"check_interval"`
+		*Alias
+	}{Alias: (*Alias)(s)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
 	}
 
+	if aux.ListenPort != nil {
+		switch v := aux.ListenPort.(type) {
+		case string:
+			p, err := strconv.Atoi(v)
+			if err != nil {
+				return err
+			}
+			s.ListenPort = p
+		case float64:
+			s.ListenPort = int(v)
+		}
+	}
+
+	if aux.CheckInterval != nil {
+		switch v := aux.CheckInterval.(type) {
+		case string:
+			p, err := strconv.Atoi(v)
+			if err != nil {
+				return err
+			}
+			s.CheckInterval = p
+		case float64:
+			s.CheckInterval = int(v)
+		}
+	}
+
+	return nil
+}

--- a/templates/server.html
+++ b/templates/server.html
@@ -193,6 +193,7 @@
             $.validator.setDefaults({
                 submitHandler: function () {
                     submitServerInterfaceSetting();
+                    return false;
                 }
             });
             $("#frm_server_interface").validate({


### PR DESCRIPTION
## Summary
- prevent default form post in server interface settings

## Testing
- ❌ `go vet ./...` *(failed: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843e76e87a88327a24741c0a78dc910