### PR TITLE
Improve install scripts with SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ chmod +x install.sh
 sudo ./install.sh
 ```
 
+During installation you will be asked for a domain name. If provided, the script
+sets up Nginx and obtains a Let's Encrypt certificate so the panel is available
+over HTTPS.
+
 ### Manual Installation
 
 1. Install required packages:
@@ -90,6 +94,7 @@ After installation, you can access the web interface at:
 ```
 http://YOUR_SERVER_IP:8080
 ```
+If you provided a domain during installation, use `https://your-domain` instead.
 
 ## Security Considerations
 

--- a/manage.sh
+++ b/manage.sh
@@ -108,7 +108,7 @@ change_port() {
     if [ ! -f "/etc/vwireguard/config.toml" ]; then
         echo -e "${RED}Config file not found${NC}"
         return
-    }
+    fi
     
     # Stop the service
     systemctl stop vwireguard
@@ -175,7 +175,42 @@ manage_ssl() {
     echo "2. Renew SSL Certificate"
     echo "3. View SSL Status"
     read -r ssl_choice
-    # Add your SSL management logic here
+    case $ssl_choice in
+        1)
+            read -rp "Enter domain: " domain
+            read -rp "Enter email (leave blank to skip): " email
+            apt-get install -y nginx certbot python3-certbot-nginx
+            cat > /etc/nginx/sites-available/vwireguard <<CONF
+server {
+    listen 80;
+    server_name ${domain};
+    location / {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+CONF
+            ln -sf /etc/nginx/sites-available/vwireguard /etc/nginx/sites-enabled/vwireguard
+            nginx -s reload || systemctl restart nginx
+            if [ -n "$email" ]; then
+                certbot --nginx --non-interactive --agree-tos -m "$email" -d "$domain"
+            else
+                certbot --nginx --register-unsafely-without-email --non-interactive --agree-tos -d "$domain"
+            fi
+            ;;
+        2)
+            certbot renew --quiet
+            ;;
+        3)
+            certbot certificates
+            ;;
+        *)
+            echo -e "${RED}Invalid option${NC}"
+            ;;
+    esac
 }
 
 manage_ip_limit() {


### PR DESCRIPTION
## Summary
- prompt for domain in `install.sh`
- automatically set up nginx and Let's Encrypt if a domain is provided
- show appropriate access URL after installation
- implement SSL management in `manage.sh`
- document optional domain/HTTPS setup in README
- fix quoting issues in nginx config snippets

## Testing
- `bash -n install.sh`
- `bash -n manage.sh`
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68443d30f1008327b51502dbcf6cf4a6