### PR TITLE
Improve clients page styling

### DIFF
--- a/templates/clients.html
+++ b/templates/clients.html
@@ -1,312 +1,8 @@
-﻿{{define "title"}}
+{{define "title"}}
 <span data-translate="Wireguard Clients">Wireguard Clients</span>
 {{end}}
 
 {{define "top_css"}}
-<style>
-    .paused-client {
-        transition: transform .2s;
-        cursor: pointer;
-    }
-    i[class^="paused-client"]:hover { transform: scale(1.5); }
-    
-    /* Modern TailwindCSS styling for info-box components */
-    .info-box {
-        background: linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0.85) 100%);
-        backdrop-filter: blur(10px);
-        border: 1px solid rgba(255,255,255,0.2);
-        border-radius: 1rem;
-        box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    }
-    
-    .info-box:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.15);
-        border-color: rgba(249,115,22,0.3);
-    }
-    
-    .dark .info-box {
-        background: linear-gradient(135deg, rgba(31,41,55,0.95) 0%, rgba(55,65,81,0.85) 100%);
-        border: 1px solid rgba(75,85,99,0.3);
-    }
-    
-    .dark .info-box:hover {
-        box-shadow: 0 8px 25px rgba(0,0,0,0.4);
-        border-color: rgba(249,115,22,0.4);
-    }
-    
-    .info-box .info-box-content {
-        padding: 1.5rem;
-    }
-    
-    .info-box .info-box-icon {
-        background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
-        border-radius: 0.75rem;
-        padding: 1rem;
-        color: white;
-        font-size: 1.5rem;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 3rem;
-        height: 3rem;
-        box-shadow: 0 4px 6px rgba(249,115,22,0.2);
-    }
-    
-    .info-box .info-box-text {
-        color: #374151;
-        font-size: 0.875rem;
-        margin-bottom: 0.5rem;
-    }
-    
-    .dark .info-box .info-box-text {
-        color: #d1d5db;
-    }
-    
-    .info-box .info-box-number {
-        font-size: 1.5rem;
-        font-weight: 700;
-        color: #111827;
-        margin-bottom: 0.25rem;
-    }
-    
-    .dark .info-box .info-box-number {
-        color: #f9fafb;
-    }
-    
-    .badge-secondary {
-        background: linear-gradient(135deg, #6b7280 0%, #4b5563 100%);
-        color: white;
-        padding: 0.25rem 0.75rem;
-        border-radius: 9999px;
-        font-size: 0.75rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        display: inline-block;
-        margin: 0.125rem;
-    }
-    
-    .btn-outline-primary {
-        background: transparent;
-        border: 2px solid #f97316;
-        color: #f97316;
-        padding: 0.5rem 1rem;
-        border-radius: 0.5rem;
-        font-size: 0.875rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        transition: all 0.2s ease;
-        cursor: pointer;
-    }
-    
-    .btn-outline-primary:hover {
-        background: #f97316;
-        color: white;
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(249,115,22,0.3);
-    }
-    
-    .btn-more {
-        background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
-        color: white;
-        padding: 0.5rem 1rem;
-        border-radius: 0.5rem;
-        font-size: 0.875rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        transition: all 0.2s ease;
-        cursor: pointer;
-        border: none;
-    }
-    
-    .btn-more:hover {
-        background: linear-gradient(135deg, #ea580c 0%, #dc2626 100%);
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(249,115,22,0.3);
-    }
-    
-    .overlay {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.7);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border-radius: 1rem;
-        z-index: 10;
-    }
-    
-    .progress {
-        background: #e5e7eb;
-        border-radius: 0.5rem;
-        height: 0.5rem;
-        overflow: hidden;
-        margin-top: 0.5rem;
-    }
-    
-    .progress-bar {
-        height: 100%;
-        background: linear-gradient(90deg, #22c55e 0%, #16a34a 100%);
-        transition: width 0.3s ease;
-    }
-    
-    .progress-bar.bg-danger {
-        background: linear-gradient(90deg, #ef4444 0%, #dc2626 100%);
-    }
-    
-    .progress-bar.bg-primary {
-        background: linear-gradient(90deg, #f97316 0%, #ea580c 100%);
-    }
-    
-    .dark .progress {
-        background: #374151;
-    }
-    
-    .form-control {
-        background: white;
-        border: 1px solid #d1d5db;
-        border-radius: 0.5rem;
-        padding: 0.5rem 0.75rem;
-        font-size: 0.875rem;
-        transition: all 0.2s ease;
-    }
-    
-    .form-control:focus {
-        outline: none;
-        border-color: #f97316;
-        box-shadow: 0 0 0 3px rgba(249,115,22,0.1);
-    }
-    
-    .dark .form-control {
-        background: #374151;
-        border-color: #4b5563;
-        color: #d1d5db;
-    }
-    
-    .custom-control-input:checked ~ .custom-control-label::before {
-        background: #f97316;
-        border-color: #f97316;
-    }
-    
-    .custom-control-input:focus ~ .custom-control-label::before {
-        box-shadow: 0 0 0 3px rgba(249,115,22,0.1);
-    }
-    
-    .btn-outline-secondary {
-        background: transparent;
-        border: 2px solid #6b7280;
-        color: #6b7280;
-        padding: 0.5rem 1rem;
-        border-radius: 0.5rem;
-        font-size: 0.875rem;
-        font-weight: 600;
-        transition: all 0.2s ease;
-        cursor: pointer;
-    }
-    
-    .btn-outline-secondary:hover {
-        background: #6b7280;
-        color: white;
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(107,114,128,0.3);
-    }
-    
-    .text-success {
-        color: #059669;
-    }
-    
-    .text-danger {
-        color: #dc2626;
-    }
-    
-    .text-muted {
-        color: #6b7280;
-    }
-    
-    .dark .text-muted {
-        color: #9ca3af;
-    }
-    
-    .card {
-        background: white;
-        border: 1px solid #e5e7eb;
-        border-radius: 1rem;
-        box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-        transition: all 0.3s ease;
-    }
-    
-    .card:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.15);
-    }
-    
-    .dark .card {
-        background: #1f2937;
-        border-color: #374151;
-    }
-    
-    .ip-allocation {
-        display: inline-block;
-        background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
-        color: white;
-        padding: 0.25rem 0.75rem;
-        border-radius: 9999px;
-        font-size: 0.75rem;
-        font-weight: 600;
-        margin: 0.125rem;
-        box-shadow: 0 2px 4px rgba(249,115,22,0.2);
-    }
-    
-    .client-status {
-        padding: 0.25rem 0.75rem;
-        border-radius: 9999px;
-        font-size: 0.75rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-    }
-    
-    .client-status.enabled {
-        background: rgba(34, 197, 94, 0.1);
-        color: #22c55e;
-        border: 1px solid rgba(34, 197, 94, 0.2);
-    }
-    
-    .client-status.disabled {
-        background: rgba(239, 68, 68, 0.1);
-        color: #ef4444;
-        border: 1px solid rgba(239, 68, 68, 0.2);
-    }
-    
-    .custom-scrollbar::-webkit-scrollbar {
-        width: 8px;
-    }
-    
-    .custom-scrollbar::-webkit-scrollbar-track {
-        background: #f1f5f9;
-        border-radius: 10px;
-    }
-    
-    .custom-scrollbar::-webkit-scrollbar-thumb {
-        background: #f97316;
-        border-radius: 10px;
-    }
-    
-    .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-        background: #ea580c;
-    }
-    
-    .dark .custom-scrollbar::-webkit-scrollbar-track {
-        background: #374151;
-    }
-</style>
 {{end}}
 
 {{define "username"}}
@@ -321,40 +17,35 @@
 <section class="content">
     <div class="container-fluid">
         <!-- <h5 class="mt-4 mb-2">Wireguard Clients</h5> -->
-        <div class="row mb-2">
-            <div class="col-12 d-flex justify-content-end align-items-center">
-                <div class="mr-3">
-                    <div class="custom-control custom-switch">
-                        <input type="checkbox" class="custom-control-input" id="auto-refresh-toggle">
-                        <label class="custom-control-label" for="auto-refresh-toggle" data-translate="Auto Refresh">Auto Refresh</label>
-                    </div>
-                </div>
-                <select id="refresh-interval" class="form-control mr-2" style="width: auto;" disabled>
-                    <option value="5" data-translate="5 seconds">5 seconds</option>
-                    <option value="10" data-translate="10 seconds">10 seconds</option>
-                    <option value="30" data-translate="30 seconds">30 seconds</option>
-                    <option value="60" data-translate="60 seconds">60 seconds</option>
-                </select>
-                <button type="button" id="refresh-status-btn" class="btn btn-outline-secondary">
-                    <i class="fas fa-sync-alt"></i> <span data-translate="Refresh Status">Refresh Status</span>
-                </button>
-            </div>
+        <div class="mb-4 flex justify-end items-center space-x-4 rtl:space-x-reverse">
+            <label class="inline-flex items-center cursor-pointer">
+                <input type="checkbox" id="auto-refresh-toggle" class="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded">
+                <span class="ml-2 rtl:ml-0 rtl:mr-2 text-sm" data-translate="Auto Refresh">Auto Refresh</span>
+            </label>
+            <select id="refresh-interval" class="px-2 py-1 text-sm border border-gray-300 dark:border-dark-600 rounded-xl bg-white dark:bg-dark-700 text-gray-700 dark:text-gray-300 focus:outline-none" disabled>
+                <option value="5" data-translate="5 seconds">5 seconds</option>
+                <option value="10" data-translate="10 seconds">10 seconds</option>
+                <option value="30" data-translate="30 seconds">30 seconds</option>
+                <option value="60" data-translate="60 seconds">60 seconds</option>
+            </select>
+            <button type="button" id="refresh-status-btn" class="px-4 py-2 text-sm font-medium text-primary-600 border border-primary-500 rounded-xl hover:bg-primary-50 dark:hover:bg-dark-700 flex items-center space-x-2 rtl:space-x-reverse">
+                <i class="fas fa-sync-alt"></i>
+                <span data-translate="Refresh Status">Refresh Status</span>
+            </button>
         </div>
-        
+
         <!-- Search and Filter Row -->
-        <div class="row mb-3" id="search-form" style="display: none;">
-            <div class="col-md-8">
-                <div class="input-group">
-                    <div class="input-group-prepend">
-                        <span class="input-group-text">
-                            <i class="fas fa-search"></i>
-                        </span>
-                    </div>
-                    <input type="text" id="search-input" class="form-control" placeholder="Search clients..." data-translate-placeholder="Search clients...">
+        <div class="mb-6 grid grid-cols-1 md:grid-cols-8 gap-4 hidden" id="search-form">
+            <div class="md:col-span-5">
+                <div class="relative">
+                    <span class="absolute inset-y-0 left-0 rtl:left-auto rtl:right-0 flex items-center pl-3 rtl:pl-0 rtl:pr-3 text-gray-400">
+                        <i class="fas fa-search"></i>
+                    </span>
+                    <input type="text" id="search-input" class="block w-full pl-10 rtl:pl-3 rtl:pr-10 text-sm border border-gray-300 dark:border-dark-600 rounded-xl bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder="Search clients..." data-translate-placeholder="Search clients...">
                 </div>
             </div>
-            <div class="col-md-4">
-                <select id="status-selector" class="form-control">
+            <div class="md:col-span-3">
+                <select id="status-filter" class="block w-full px-3 py-2 text-sm border border-gray-300 dark:border-dark-600 rounded-xl bg-white dark:bg-dark-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
                     <option value="All" data-translate="All">All</option>
                     <option value="Enabled" data-translate="Enabled">Enabled</option>
                     <option value="Disabled" data-translate="Disabled">Disabled</option>
@@ -363,115 +54,106 @@
                 </select>
             </div>
         </div>
-        
-        <div class="row" id="client-list">
+        <div id="loading-state" class="hidden flex flex-col items-center py-10">
+            <i class="fas fa-spinner fa-spin text-gray-500 text-xl"></i>
+            <span class="mt-2 text-gray-500 dark:text-gray-400" data-translate="Loading...">Loading...</span>
+        </div>
+        <div id="empty-state" class="hidden text-center py-10">
+            <span class="text-gray-500 dark:text-gray-400" data-translate="No clients found">No clients found</span>
+        </div>
+
+        <div id="clients-container" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         </div>
         <!-- /.row -->
     </div>
 </section>
 
-<div class="modal fade" id="modal_email_client">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="Email Configuration">Email Configuration</h4>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <form name="frm_email_client" id="frm_email_client">
-                <div class="modal-body">
-                    <input type="hidden" id="e_client_id" name="e_client_id">
-                    <div class="form-group">
-                        <label for="e_client_email" class="control-label" data-translate="Email address">Email address</label>
-                        <input type="text" class="form-control" id="e_client_email" name="e_client_email">
-                    </div>
-                </div>
-                <div class="modal-footer justify-content-between">
-                    <button type="button" class="btn btn-default" data-dismiss="modal" data-translate="Cancel">Cancel</button>
-                    <button type="submit" class="btn btn-success" data-translate="Send">Send</button>
-                </div>
-            </form>
+<div id="modal_email_client" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50 flex items-center justify-center p-4">
+    <div class="bg-white dark:bg-dark-800 rounded-2xl shadow-2xl w-full max-w-md">
+        <div class="flex items-center justify-between p-6 border-b border-gray-200 dark:border-dark-700">
+            <h4 class="text-lg font-semibold text-gray-900 dark:text-white" data-translate="Email Configuration">Email Configuration</h4>
+            <button type="button" onclick="document.getElementById('modal_email_client').style.display='none'" class="p-2 hover:bg-gray-100 dark:hover:bg-dark-700 rounded-lg">
+                <i class="fas fa-times text-gray-400"></i>
+            </button>
         </div>
-        <!-- /.modal-content -->
+        <form name="frm_email_client" id="frm_email_client" class="p-6 space-y-4">
+            <input type="hidden" id="e_client_id" name="e_client_id">
+            <div>
+                <label for="e_client_email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" data-translate="Email address">Email address</label>
+                <input type="text" id="e_client_email" name="e_client_email" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500">
+            </div>
+            <div class="flex justify-end space-x-3 rtl:space-x-reverse">
+                <button type="button" onclick="document.getElementById('modal_email_client').style.display='none'" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Cancel">Cancel</button>
+                <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-primary-500 to-primary-600 border border-transparent rounded-xl hover:from-primary-600 hover:to-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Send">Send</button>
+            </div>
+        </form>
     </div>
-    <!-- /.modal-dialog -->
 </div>
-<!-- /.modal -->
 
-<div class="modal fade" id="modal_qr_client">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="QR Code">QR Code</h4>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <input type="hidden" id="qr_client_id" name="qr_client_id">
-                <img id="qr_code" class="w-100" style="image-rendering: pixelated;" src="" alt="QR code" />
-                <!-- do not include FwMark in any client configs: it is INVALID. -->
-            </div>
+<div id="modal_qr_code" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50 flex items-center justify-center p-4">
+    <div class="bg-white dark:bg-dark-800 rounded-2xl shadow-2xl w-full max-w-md">
+        <div class="flex items-center justify-between p-6 border-b border-gray-200 dark:border-dark-700">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+                <span data-translate="QR Code">QR Code</span>
+            </h3>
+            <button type="button" onclick="document.getElementById('modal_qr_code').style.display='none'" class="p-2 hover:bg-gray-100 dark:hover:bg-dark-700 rounded-lg">
+                <i class="fas fa-times text-gray-400"></i>
+            </button>
         </div>
-        <!-- /.modal-content -->
-    </div>
-    <!-- /.modal-dialog -->
-</div>
-<!-- /.modal -->
-
-<div class="modal fade" id="modal_telegram_client">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="Telegram Configuration">Telegram Configuration</h4>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+        <div class="p-6 text-center">
+            <input type="hidden" id="qr_client_id" name="qr_client_id">
+            <div class="bg-gray-100 dark:bg-dark-700 rounded-xl p-4 mb-4">
+                <img id="qr_code" class="w-full h-auto max-w-xs mx-auto" style="image-rendering: pixelated;" src="" alt="QR code" />
             </div>
-            <form name="frm_telegram_client" id="frm_telegram_client">
-                <div class="modal-body">
-                    <input type="hidden" id="tg_client_id" name="tg_client_id">
-                    <div class="form-group">
-                        <label for="tg_client_userid" class="control-label" data-translate="Telegram userid">Telegram userid</label>
-                        <input type="text" class="form-control" id="tg_client_userid" name="tg_client_userid">
-                    </div>
-                </div>
-                <div class="modal-footer justify-content-between">
-                    <button type="button" class="btn btn-default" data-dismiss="modal" data-translate="Cancel">Cancel</button>
-                    <button type="submit" class="btn btn-success" data-translate="Send">Send</button>
-                </div>
-            </form>
+            <p class="text-sm text-gray-600 dark:text-gray-400" data-translate="Scan this QR code with your Wireguard client">Scan this QR code with your Wireguard client</p>
         </div>
-        <!-- /.modal-content -->
     </div>
-    <!-- /.modal-dialog -->
 </div>
-<!-- /.modal -->
 
-<div class="modal fade" id="modal_edit_client">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="Edit Client">Edit Client</h4>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+<div id="modal_telegram_client" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50 flex items-center justify-center p-4">
+    <div class="bg-white dark:bg-dark-800 rounded-2xl shadow-2xl w-full max-w-md">
+        <div class="flex items-center justify-between p-6 border-b border-gray-200 dark:border-dark-700">
+            <h4 class="text-lg font-semibold text-gray-900 dark:text-white" data-translate="Telegram Configuration">Telegram Configuration</h4>
+            <button type="button" onclick="document.getElementById('modal_telegram_client').style.display='none'" class="p-2 hover:bg-gray-100 dark:hover:bg-dark-700 rounded-lg">
+                <i class="fas fa-times text-gray-400"></i>
+            </button>
+        </div>
+        <form name="frm_telegram_client" id="frm_telegram_client" class="p-6 space-y-4">
+            <input type="hidden" id="tg_client_id" name="tg_client_id">
+            <div>
+                <label for="tg_client_userid" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" data-translate="Telegram userid">Telegram userid</label>
+                <input type="text" id="tg_client_userid" name="tg_client_userid" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500">
             </div>
-            <form name="frm_edit_client" id="frm_edit_client">
-                <div class="modal-body">
-                    <input type="hidden" id="_client_id" name="_client_id">
+            <div class="flex justify-end space-x-3 rtl:space-x-reverse">
+                <button type="button" onclick="document.getElementById('modal_telegram_client').style.display='none'" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Cancel">Cancel</button>
+                <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-primary-500 to-primary-600 border border-transparent rounded-xl hover:from-primary-600 hover:to-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Send">Send</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="modal_edit_client" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50 flex items-center justify-center p-4 overflow-y-auto">
+    <div class="bg-white dark:bg-dark-800 rounded-2xl shadow-2xl w-full max-w-2xl">
+        <div class="flex items-center justify-between p-6 border-b border-gray-200 dark:border-dark-700">
+            <h4 class="text-lg font-semibold text-gray-900 dark:text-white" data-translate="Edit Client">Edit Client</h4>
+            <button type="button" onclick="document.getElementById('modal_edit_client').style.display='none'" class="p-2 hover:bg-gray-100 dark:hover:bg-dark-700 rounded-lg">
+                <i class="fas fa-times text-gray-400"></i>
+            </button>
+        </div>
+        <form name="frm_edit_client" id="frm_edit_client" class="p-6 space-y-4 overflow-y-auto max-h-screen">
+            <input type="hidden" id="_client_id" name="_client_id">
+            <div class="space-y-4">
                     <div class="form-group">
                         <label for="_client_name" class="control-label" data-translate="Name">Name</label>
-                        <input type="text" class="form-control" id="_client_name" name="_client_name">
+                        <input type="text" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_name" name="_client_name">
                     </div>
                     <div class="form-group">
                         <label for="_client_email" class="control-label" data-translate="Email">Email</label>
-                        <input type="text" class="form-control" id="_client_email" name="client_email">
+                        <input type="text" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_email" name="client_email">
                     </div>
                     <div class="form-group">
                         <label for="_client_quota" class="control-label" data-translate="Quota">Quota</label>
-                        <select class="form-control" id="_quota_preset" onchange="updateQuotaInput()">
+                        <select class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_quota_preset" onchange="updateQuotaInput()">
                             <option value="" data-translate="Select Quota">Select Quota</option>
                             <option value="10">10 GB</option>
                             <option value="20">20 GB</option>
@@ -486,29 +168,29 @@
                         </select>
                     </div>
                     <div class="form-group">
-                        <input type="number" class="form-control" id="_client_quota" name="_client_quota" data-translate-placeholder="Enter custom quota in GB" placeholder="Enter custom quota in GB" step="0.1" min="0" />
+                        <input type="number" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_quota" name="_client_quota" data-translate-placeholder="Enter custom quota in GB" placeholder="Enter custom quota in GB" step="0.1" min="0" />
                     </div>
 
                     <div class="form-group">
                         <label for="_client_expiration_days" class="control-label" data-translate="Expiration Days">Expiration Days</label>
-                        <input type="number" class="form-control" id="_client_expiration_days" name="_client_expiration_days" placeholder="e.g. 30" min="0" />
+                        <input type="number" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_expiration_days" name="_client_expiration_days" placeholder="e.g. 30" min="0" />
                     </div>
 
                     <div class="form-group">
                         <label for="_client_allocated_ips" class="control-label" data-translate="IP Allocation">IP Allocation</label>
-                        <input type="text" data-role="tagsinput" class="form-control" id="_client_allocated_ips">
+                        <input type="text" data-role="tagsinput" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_allocated_ips">
                     </div>
                     <div class="form-group">
                         <label for="_client_endpoint" class="control-label" data-translate="Endpoint">Endpoint</label>
-                        <input type="text" class="form-control" id="_client_endpoint" name="client_endpoint">
+                        <input type="text" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_endpoint" name="client_endpoint">
                     </div>
                     <div class="form-group" style="margin-top: 0.5rem;">
                         <label for="_client_telegram_userid" class="control-label" data-translate="Telegram userid">Telegram userid</label>
-                        <input type="text" class="form-control" id="_client_telegram_userid" name="_client_telegram_userid">
+                        <input type="text" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_telegram_userid" name="_client_telegram_userid">
                     </div>
                     <div class="form-group">
                         <label for="_additional_notes" class="control-label" data-translate="Notes">Notes</label>
-                        <textarea class="form-control" style="min-height: 6rem;" id="_additional_notes" name="_additional_notes" data-translate-placeholder="Additional notes about this client" placeholder="Additional notes about this client"></textarea>
+                        <textarea class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" style="min-height: 6rem;" id="_additional_notes" name="_additional_notes" data-translate-placeholder="Additional notes about this client" placeholder="Additional notes about this client"></textarea>
                     </div>
                     <div class="form-group">
                         <div class="icheck-primary d-inline">
@@ -538,13 +220,13 @@
                             <label for="_client_public_key" class="control-label" data-translate="Public Key">
                                 Public Key
                             </label>
-                            <input type="text" class="form-control" id="_client_public_key" name="_client_public_key" aria-invalid="false">
+                            <input type="text" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_public_key" name="_client_public_key" aria-invalid="false">
                         </div>
                         <div class="form-group">
                             <label for="_client_preshared_key" class="control-label" data-translate="Preshared Key">
                                 Preshared Key
                             </label>
-                            <input type="text" class="form-control" id="_client_preshared_key" name="_client_preshared_key">
+                            <input type="text" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_preshared_key" name="_client_preshared_key">
                         </div>
                     </details>
                     <details style="margin-top: 0.5rem;">
@@ -553,11 +235,11 @@
                         </summary>
                         <div class="form-group">
                             <label for="_client_allowed_ips" class="control-label" data-translate="Allowed IPs">Allowed IPs</label>
-                            <input type="text" data-role="tagsinput" class="form-control" id="_client_allowed_ips">
+                            <input type="text" data-role="tagsinput" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="_client_allowed_ips">
                         </div>
                         <div class="form-group">
                             <label for="_client_extra_allowed_ips" class="control-label" data-translate="Extra Allowed IPs">Extra Allowed IPs</label>
-                            <input type="text" data-role="tagsinput" class="form-control"
+                            <input type="text" data-role="tagsinput" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"
                                    id="_client_extra_allowed_ips">
                         </div>
                         <div class="form-group">
@@ -569,61 +251,45 @@
                         </div>
                     </details>
                 </div>
-                <div class="modal-footer justify-content-between">
-                    <button type="button" class="btn btn-default" data-dismiss="modal" data-translate="Cancel">Cancel</button>
-                    <button type="submit" class="btn btn-success" data-translate="Save">Save</button>
-                </div>
-            </form>
-        </div>
-        <!-- /.modal-content -->
+            <div class="flex justify-end space-x-3 rtl:space-x-reverse pt-4">
+                <button type="button" onclick="document.getElementById('modal_edit_client').style.display='none'" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Cancel">Cancel</button>
+                <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-primary-500 to-primary-600 border border-transparent rounded-xl hover:from-primary-600 hover:to-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Save">Save</button>
+            </div>
+        </form>
     </div>
-    <!-- /.modal-dialog -->
 </div>
-<!-- /.modal -->
 
-<div class="modal fade" id="modal_pause_client">
-    <div class="modal-dialog">
-        <div class="modal-content bg-warning">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="Disable">Disable</h4>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-            </div>
-            <div class="modal-footer justify-content-between">
-                <button type="button" class="btn btn-outline-dark" data-dismiss="modal" data-translate="Cancel">Cancel</button>
-                <button type="button" class="btn btn-outline-dark" id="pause_client_confirm" data-translate="Apply">Apply</button>
-            </div>
+<div id="modal_pause_client" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50 flex items-center justify-center p-4">
+    <div class="bg-white dark:bg-dark-800 rounded-2xl shadow-2xl w-full max-w-md">
+        <div class="flex items-center justify-between p-6 border-b border-gray-200 dark:border-dark-700 bg-warning-100 dark:bg-warning-900/20">
+            <h4 class="text-lg font-semibold text-gray-900 dark:text-white" data-translate="Disable">Disable</h4>
+            <button type="button" onclick="document.getElementById('modal_pause_client').style.display='none'" class="p-2 hover:bg-gray-100 dark:hover:bg-dark-700 rounded-lg">
+                <i class="fas fa-times text-gray-400"></i>
+            </button>
         </div>
-        <!-- /.modal-content -->
+        <div class="p-6" id="modal_pause_client_body"></div>
+        <div class="flex justify-end space-x-3 rtl:space-x-reverse p-6 pt-0">
+            <button type="button" onclick="document.getElementById('modal_pause_client').style.display='none'" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Cancel">Cancel</button>
+            <button type="button" id="pause_client_confirm" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Apply">Apply</button>
+        </div>
     </div>
-    <!-- /.modal-dialog -->
 </div>
-<!-- /.modal -->
 
-<div class="modal fade" id="modal_remove_client">
-    <div class="modal-dialog">
-        <div class="modal-content bg-danger">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="Remove">Remove</h4>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-            </div>
-            <div class="modal-footer justify-content-between">
-                <button type="button" class="btn btn-outline-dark" data-dismiss="modal" data-translate="Cancel">Cancel</button>
-                <button type="button" class="btn btn-outline-dark" id="remove_client_confirm" data-translate="Apply">Apply</button>
-            </div>
+<div id="modal_remove_client" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50 flex items-center justify-center p-4">
+    <div class="bg-white dark:bg-dark-800 rounded-2xl shadow-2xl w-full max-w-md">
+        <div class="flex items-center justify-between p-6 border-b border-gray-200 dark:border-dark-700 bg-danger-100 dark:bg-danger-900/20">
+            <h4 class="text-lg font-semibold text-gray-900 dark:text-white" data-translate="Remove">Remove</h4>
+            <button type="button" onclick="document.getElementById('modal_remove_client').style.display='none'" class="p-2 hover:bg-gray-100 dark:hover:bg-dark-700 rounded-lg">
+                <i class="fas fa-times text-gray-400"></i>
+            </button>
         </div>
-        <!-- /.modal-content -->
+        <div class="p-6" id="modal_remove_client_body"></div>
+        <div class="flex justify-end space-x-3 rtl:space-x-reverse p-6 pt-0">
+            <button type="button" onclick="document.getElementById('modal_remove_client').style.display='none'" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Cancel">Cancel</button>
+            <button type="button" id="remove_client_confirm" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Apply">Apply</button>
+        </div>
     </div>
-    <!-- /.modal-dialog -->
 </div>
-<!-- /.modal -->
                 <span data-translate="QR Code">QR Code</span>
             </h3>
             <button onclick="document.getElementById('modal_qr_code').style.display='none'" class="p-2 hover:bg-gray-100 dark:hover:bg-dark-700 rounded-lg">
@@ -655,8 +321,8 @@ const loadingState = document.getElementById('loading-state');
 const emptyState = document.getElementById('empty-state');
 const searchInput = document.getElementById('search-input');
 const statusFilter = document.getElementById('status-filter');
-const autoRefreshToggle = document.getElementById('auto-refresh');
-const refreshBtn = document.getElementById('refresh-btn');
+const autoRefreshToggle = document.getElementById('auto-refresh-toggle');
+const refreshBtn = document.getElementById('refresh-status-btn');
 
 // Statistics elements
 const totalClientsEl = document.getElementById('total-clients');

--- a/templates/status.html
+++ b/templates/status.html
@@ -31,42 +31,52 @@ Connected Peers
 <section class="content">
     <div class="container-fluid">
         {{ if .error }}
-        <div class="alert alert-warning" role="alert">{{.error}}</div>
-        {{ end}}
+        <div class="mb-4 px-4 py-3 text-yellow-800 bg-yellow-50 rounded-xl border border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-200" role="alert">{{.error}}</div>
+        {{ end }}
         {{ range $dev := .devices }}
-            <table class="table table-sm">
-                <caption>List of connected peers for device with name {{ $dev.Name }} </caption>
-              <thead>
-                <tr>
-                  <th scope="col">#</th>
-                  <th scope="col">Name</th>
-                  <th scope="col">Email</th>
-                  <th scope="col">Allocated IPs</th>
-                  <th scope="col">Endpoint</th>
-                  <th scope="col">Public Key</th>
-                  <th scope="col">Received</th>
-                  <th scope="col">Transmitted</th>
-                  <th scope="col">Connected (Approximation)</th>
-                  <th scope="col">Last Handshake</th>
-                </tr>
-              </thead>
-              <tbody>
-              {{ range $idx, $peer := $dev.Peers }}
-              <tr {{ if $peer.Connected }} class="table-success" {{ end }}>
-                <th scope="row">{{ $idx }}</th>
-                <td>{{ $peer.Name }}</td>
-                <td>{{ $peer.Email }}</td>
-                <td>{{ $peer.AllocatedIP }}</td>
-                <td>{{ $peer.Endpoint }}</td>
-                <td>{{ $peer.PublicKey }}</td>
-                <td title="{{ $peer.ReceivedBytes }} Bytes"><script>document.write(bytesToHumanReadable({{ $peer.ReceivedBytes }}))</script></td>
-                <td title="{{ $peer.TransmitBytes }} Bytes"><script>document.write(bytesToHumanReadable({{ $peer.TransmitBytes }}))</script></td>
-                <td>{{ if $peer.Connected }}✓{{end}}</td>
-                <td>{{ $peer.LastHandshakeTime.Format "2006-01-02 15:04:05 MST" }}</td>
-               </tr>
-              {{ end }}
-              </tbody>
-            </table>
+        <div class="bg-white dark:bg-dark-800 rounded-2xl shadow-soft border border-gray-200 dark:border-dark-700 mb-8">
+            <div class="px-6 py-4 bg-gradient-to-r from-primary-500 to-primary-600 rounded-t-2xl">
+                <h3 class="text-lg font-semibold text-white flex items-center">
+                    <i class="fas fa-network-wired mr-2 rtl:mr-0 rtl:ml-2"></i>
+                    <span>Device: {{ $dev.Name }}</span>
+                </h3>
+            </div>
+            <div class="p-6 overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-dark-600 text-sm text-left rtl:text-right">
+                    <caption class="sr-only">List of connected peers for device {{ $dev.Name }}</caption>
+                    <thead class="bg-gray-50 dark:bg-dark-700">
+                        <tr>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">#</th>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">Name</th>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">Email</th>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">Allocated IPs</th>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">Endpoint</th>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">Public Key</th>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">Received</th>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">Transmitted</th>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">Connected (Approximation)</th>
+                            <th scope="col" class="px-4 py-2 font-semibold text-gray-600 dark:text-gray-300">Last Handshake</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 dark:divide-dark-700">
+                    {{ range $idx, $peer := $dev.Peers }}
+                    <tr {{ if $peer.Connected }}class="bg-green-50 dark:bg-green-900/20"{{ end }}>
+                        <th scope="row" class="px-4 py-2 font-medium text-gray-700 dark:text-gray-200">{{ $idx }}</th>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $peer.Name }}</td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $peer.Email }}</td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $peer.AllocatedIP }}</td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $peer.Endpoint }}</td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $peer.PublicKey }}</td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300" title="{{ $peer.ReceivedBytes }} Bytes"><script>document.write(bytesToHumanReadable({{ $peer.ReceivedBytes }}))</script></td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300" title="{{ $peer.TransmitBytes }} Bytes"><script>document.write(bytesToHumanReadable({{ $peer.TransmitBytes }}))</script></td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ if $peer.Connected }}✓{{end}}</td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $peer.LastHandshakeTime.Format "2006-01-02 15:04:05 MST" }}</td>
+                    </tr>
+                    {{ end }}
+                    </tbody>
+                </table>
+            </div>
+        </div>
         {{ end }}
     </div>
 </section>


### PR DESCRIPTION
## Summary
- restyle clients page modals using Tailwind and fix missing QR modal
- add loading and empty states, update element IDs
- fix JS element selectors to match new IDs

## Testing
- `go test ./...` *(fails: fetching modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6867ee8d27008327ad9fd91607c52912