### PR TITLE
Fix quota reset on config apply

### DIFF
--- a/model/client.go
+++ b/model/client.go
@@ -37,11 +37,13 @@ type Client struct {
 
 // ClientUsageData stores persistent usage information
 type ClientUsageData struct {
-	TotalBytesReceived uint64    `json:"total_bytes_received"`
-	TotalBytesSent     uint64    `json:"total_bytes_sent"`
-	LastSeen           time.Time `json:"last_seen"`
-	FirstSeen          time.Time `json:"first_seen"`
-	UpdatedAt          time.Time `json:"updated_at"`
+	TotalBytesReceived         uint64    `json:"total_bytes_received"`
+	TotalBytesSent             uint64    `json:"total_bytes_sent"`
+	LastInterfaceBytesReceived uint64    `json:"last_interface_bytes_received"`
+	LastInterfaceBytesSent     uint64    `json:"last_interface_bytes_sent"`
+	LastSeen                   time.Time `json:"last_seen"`
+	FirstSeen                  time.Time `json:"first_seen"`
+	UpdatedAt                  time.Time `json:"updated_at"`
 }
 
 // ClientData includes the Client and extra data


### PR DESCRIPTION
## Summary
- store last WireGuard interface counters to keep usage persistent
- accumulate bytes using the persistent counters so restart doesn't reset data
- persist last seen and quota even if the client is offline

## Testing
- `gofmt -w model/client.go handler/routes.go`
- `go vet ./...` *(fails: Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_686f9a9fd3ec8327baeae180a09a24ff