### PR TITLE
Fix quota reset on config apply

### DIFF
--- a/handler/routes.go
+++ b/handler/routes.go
@@ -507,12 +507,19 @@ func GetClients(db store.IStore) echo.HandlerFunc {
 					totalBytes := usage.Rx + usage.Tx
 					clientData.Client.UsedQuota = int64(totalBytes)
 
-					// Add last handshake time
-					clientData.Client.LastHandshake = usage.LastHandshake
+					// Add last handshake time; preserve previous if no handshake yet
+					lastSeen := usage.LastHandshake
+					if lastSeen.IsZero() && clientData.Client.PersistentUsageData != nil {
+						lastSeen = clientData.Client.PersistentUsageData.LastSeen
+					}
+					clientData.Client.LastHandshake = lastSeen
 
 					// Update persistent usage data
 					if clientData.Client.PersistentUsageData == nil {
-						clientData.Client.PersistentUsageData = &model.ClientUsageData{}
+						clientData.Client.PersistentUsageData = &model.ClientUsageData{
+							LastInterfaceBytesReceived: usage.Rx,
+							LastInterfaceBytesSent:     usage.Tx,
+						}
 					}
 
 					// Only update if we have new data
@@ -525,10 +532,28 @@ func GetClients(db store.IStore) echo.HandlerFunc {
 						}
 					}
 
-					// Update total usage (accumulate)
-					clientData.Client.PersistentUsageData.TotalBytesReceived = usage.Rx
-					clientData.Client.PersistentUsageData.TotalBytesSent = usage.Tx
+					// Compute usage delta based on last counters
+					deltaRx := usage.Rx
+					if usage.Rx >= clientData.Client.PersistentUsageData.LastInterfaceBytesReceived {
+						deltaRx = usage.Rx - clientData.Client.PersistentUsageData.LastInterfaceBytesReceived
+					}
+					deltaTx := usage.Tx
+					if usage.Tx >= clientData.Client.PersistentUsageData.LastInterfaceBytesSent {
+						deltaTx = usage.Tx - clientData.Client.PersistentUsageData.LastInterfaceBytesSent
+					}
+
+					// Accumulate totals
+					clientData.Client.PersistentUsageData.TotalBytesReceived += deltaRx
+					clientData.Client.PersistentUsageData.TotalBytesSent += deltaTx
+
+					// Update last interface counters
+					clientData.Client.PersistentUsageData.LastInterfaceBytesReceived = usage.Rx
+					clientData.Client.PersistentUsageData.LastInterfaceBytesSent = usage.Tx
+
 					clientData.Client.PersistentUsageData.UpdatedAt = time.Now().UTC()
+
+					// Update UsedQuota from persistent totals
+					clientData.Client.UsedQuota = int64(clientData.Client.PersistentUsageData.TotalBytesReceived + clientData.Client.PersistentUsageData.TotalBytesSent)
 
 					// Save the updated client data
 					if err := db.SaveClient(*clientData.Client); err != nil {
@@ -536,12 +561,17 @@ func GetClients(db store.IStore) echo.HandlerFunc {
 					}
 				} else {
 					clientData.Client.Status = "offline"
-					clientData.Client.UsedQuota = 0
-
 					// Use persistent data if available
 					if clientData.Client.PersistentUsageData != nil {
 						clientData.Client.UsedQuota = int64(clientData.Client.PersistentUsageData.TotalBytesReceived + clientData.Client.PersistentUsageData.TotalBytesSent)
 						clientData.Client.LastHandshake = clientData.Client.PersistentUsageData.LastSeen
+					} else {
+						clientData.Client.UsedQuota = 0
+					}
+
+					// Persist last seen and quota even when offline
+					if err := db.SaveClient(*clientData.Client); err != nil {
+						log.Error("Error saving client persistent data: ", err)
 					}
 				}
 

--- a/model/client.go
+++ b/model/client.go
@@ -37,11 +37,13 @@ type Client struct {
 
 // ClientUsageData stores persistent usage information
 type ClientUsageData struct {
-	TotalBytesReceived uint64    `json:"total_bytes_received"`
-	TotalBytesSent     uint64    `json:"total_bytes_sent"`
-	LastSeen           time.Time `json:"last_seen"`
-	FirstSeen          time.Time `json:"first_seen"`
-	UpdatedAt          time.Time `json:"updated_at"`
+	TotalBytesReceived         uint64    `json:"total_bytes_received"`
+	TotalBytesSent             uint64    `json:"total_bytes_sent"`
+	LastInterfaceBytesReceived uint64    `json:"last_interface_bytes_received"`
+	LastInterfaceBytesSent     uint64    `json:"last_interface_bytes_sent"`
+	LastSeen                   time.Time `json:"last_seen"`
+	FirstSeen                  time.Time `json:"first_seen"`
+	UpdatedAt                  time.Time `json:"updated_at"`
 }
 
 // ClientData includes the Client and extra data


### PR DESCRIPTION
## Summary
- store last WireGuard interface counters to keep usage persistent
- accumulate bytes using the persistent counters so restart doesn't reset data
- persist last seen and quota even if the client is offline
- preserve previous last seen when no handshake occurs after restart

## Testing
- `gofmt -w model/client.go handler/routes.go`
- `go vet ./...` *(fails: Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_686f9a9fd3ec8327baeae180a09a24ff