### PR TITLE
Fix missing edit fields causing modal crash

### DIFF
--- a/templates/clients.html
+++ b/templates/clients.html
@@ -123,30 +123,6 @@
             <button type="button" onclick="document.getElementById('modal_telegram_client').style.display='none'" class="p-2 hover:bg-gray-100 dark:hover:bg-dark-700 rounded-lg">
                 <i class="fas fa-times text-gray-400"></i>
             </button>
-=======
-<div class="modal fade" id="modal_telegram_client">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="Telegram Configuration">Telegram Configuration</h4>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <form name="frm_telegram_client" id="frm_telegram_client">
-                <div class="modal-body">
-                    <input type="hidden" id="tg_client_id" name="tg_client_id">
-                    <div class="form-group">
-                        <label for="tg_client_userid" class="control-label" data-translate="Telegram userid">Telegram userid</label>
-                        <input type="text" class="block w-full px-3 py-2 border border-gray-300 dark:border-dark-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-dark-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500" id="tg_client_userid" name="tg_client_userid">
-                    </div>
-                </div>
-                <div class="modal-footer justify-content-between">
-                    <button type="button" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-dismiss="modal" data-translate="Cancel">Cancel</button>
-                    <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-primary-500 to-primary-600 border border-transparent rounded-xl hover:from-primary-600 hover:to-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Send">Send</button>
-                </div>
-            </form>
-
         </div>
         <form name="frm_telegram_client" id="frm_telegram_client" class="p-6 space-y-4">
             <input type="hidden" id="tg_client_id" name="tg_client_id">
@@ -342,23 +318,6 @@
         <div class="flex justify-end space-x-3 rtl:space-x-reverse p-6 pt-0">
             <button type="button" onclick="document.getElementById('modal_pause_client').style.display='none'" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Cancel">Cancel</button>
             <button type="button" id="pause_client_confirm" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Apply">Apply</button>
-=======
-<div class="modal fade" id="modal_pause_client">
-    <div class="modal-dialog">
-        <div class="modal-content bg-warning">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="Disable">Disable</h4>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-            </div>
-            <div class="modal-footer justify-content-between">
-                <button type="button" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-dismiss="modal" data-translate="Cancel">Cancel</button>
-                <button type="button" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" id="pause_client_confirm" data-translate="Apply">Apply</button>
-            </div>
-
         </div>
     </div>
 </div>
@@ -375,23 +334,6 @@
         <div class="flex justify-end space-x-3 rtl:space-x-reverse p-6 pt-0">
             <button type="button" onclick="document.getElementById('modal_remove_client').style.display='none'" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Cancel">Cancel</button>
             <button type="button" id="remove_client_confirm" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-translate="Apply">Apply</button>
-
-<div class="modal fade" id="modal_remove_client">
-    <div class="modal-dialog">
-        <div class="modal-content bg-danger">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="Remove">Remove</h4>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-            </div>
-            <div class="modal-footer justify-content-between">
-                <button type="button" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" data-dismiss="modal" data-translate="Cancel">Cancel</button>
-                <button type="button" class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-dark-700 border border-gray-300 dark:border-dark-600 rounded-xl hover:bg-gray-50 dark:hover:bg-dark-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500" id="remove_client_confirm" data-translate="Apply">Apply</button>
-            </div>
-
         </div>
     </div>
 </div>
@@ -756,8 +698,10 @@ window.editClient = function(clientId) {
     document.getElementById('edit_client_use_server_dns').checked = clientData.use_server_dns;
     document.getElementById('edit_client_telegram_userid').value = clientData.tg_userid || '';
     document.getElementById('edit_client_endpoint').value = clientData.endpoint || '';
-    document.getElementById('edit_client_public_key').value = clientData.public_key || '';
-    document.getElementById('edit_client_preshared_key').value = clientData.preshared_key || '';
+    const pubKeyField = document.getElementById('edit_client_public_key');
+    if (pubKeyField) pubKeyField.value = clientData.public_key || '';
+    const preKeyField = document.getElementById('edit_client_preshared_key');
+    if (preKeyField) preKeyField.value = clientData.preshared_key || '';
     
     // Set allocated IPs
     if (clientData.allocated_ips && clientData.allocated_ips.length > 0) {
@@ -766,12 +710,14 @@ window.editClient = function(clientId) {
     
     // Set allowed IPs
     if (clientData.allowed_ips && clientData.allowed_ips.length > 0) {
-        document.getElementById('edit_client_allowed_ips').value = clientData.allowed_ips.join(',');
+        const allowedField = document.getElementById('edit_client_allowed_ips');
+        if (allowedField) allowedField.value = clientData.allowed_ips.join(',');
     }
     
     // Set extra allowed IPs
     if (clientData.extra_allowed_ips && clientData.extra_allowed_ips.length > 0) {
-        document.getElementById('edit_client_extra_allowed_ips').value = clientData.extra_allowed_ips.join(',');
+        const extraAllowedField = document.getElementById('edit_client_extra_allowed_ips');
+        if (extraAllowedField) extraAllowedField.value = clientData.extra_allowed_ips.join(',');
     }
     
     // Show the modal
@@ -919,12 +865,24 @@ document.addEventListener('DOMContentLoaded', function() {
                 use_server_dns: document.getElementById('edit_client_use_server_dns').checked,
                 tg_userid: document.getElementById('edit_client_telegram_userid').value,
                 endpoint: document.getElementById('edit_client_endpoint').value,
-                public_key: document.getElementById('edit_client_public_key').value,
-                preshared_key: document.getElementById('edit_client_preshared_key').value,
                 allocated_ips: document.getElementById('edit_client_allocated_ips').value.split(',').filter(ip => ip.trim()),
-                allowed_ips: document.getElementById('edit_client_allowed_ips').value.split(',').filter(ip => ip.trim()),
-                extra_allowed_ips: document.getElementById('edit_client_extra_allowed_ips').value.split(',').filter(ip => ip.trim()),
             };
+
+            const publicKeyInput = document.getElementById('edit_client_public_key');
+            if (publicKeyInput) updateData.public_key = publicKeyInput.value;
+
+            const preKeyInput = document.getElementById('edit_client_preshared_key');
+            if (preKeyInput) updateData.preshared_key = preKeyInput.value;
+
+            const allowedIpsInput = document.getElementById('edit_client_allowed_ips');
+            if (allowedIpsInput) {
+                updateData.allowed_ips = allowedIpsInput.value.split(',').filter(ip => ip.trim());
+            }
+
+            const extraAllowedInput = document.getElementById('edit_client_extra_allowed_ips');
+            if (extraAllowedInput) {
+                updateData.extra_allowed_ips = extraAllowedInput.value.split(',').filter(ip => ip.trim());
+            }
             
             fetch(`${basePath}/api/client/${clientId}`, {
                 method: 'PUT',
@@ -975,6 +933,18 @@ window.saveEditClient = function() {
         endpoint: document.getElementById('edit_client_endpoint').value,
         allocated_ips: document.getElementById('edit_client_allocated_ips').value.split(',').filter(ip => ip.trim()),
     };
+
+    const sPubKey = document.getElementById('edit_client_public_key');
+    if (sPubKey) updateData.public_key = sPubKey.value;
+
+    const sPreKey = document.getElementById('edit_client_preshared_key');
+    if (sPreKey) updateData.preshared_key = sPreKey.value;
+
+    const sAllowed = document.getElementById('edit_client_allowed_ips');
+    if (sAllowed) updateData.allowed_ips = sAllowed.value.split(',').filter(ip => ip.trim());
+
+    const sExtra = document.getElementById('edit_client_extra_allowed_ips');
+    if (sExtra) updateData.extra_allowed_ips = sExtra.value.split(',').filter(ip => ip.trim());
     
     // Show loading state
     const saveBtn = document.querySelector('#modal_edit_client button[onclick="saveEditClient()"]');


### PR DESCRIPTION
## Summary
- avoid referencing non-existent edit modal fields
- ensure optional client fields are handled only if present

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686f9f36f80883278977c410f9deadbd