### PR TITLE
Improve quota and expiration display

### DIFF
--- a/templates/clients.html
+++ b/templates/clients.html
@@ -479,8 +479,20 @@ function createClientCard(client) {
     // مینیمال: فقط اسم، ایمیل، حجم، زمان، IP Allocation و دکمه‌ها
     const name = clientData.name || '';
     const email = clientData.email || '';
-    const quotaText = clientData.quota ? formatBytes(clientData.quota * 1024 * 1024 * 1024) : 'Unlimited';
-    const expirationText = clientData.expiration_days ? `${clientData.expiration_days} days` : 'No expiration';
+    const quotaBytes = clientData.quota ? clientData.quota * 1024 * 1024 * 1024 : 0;
+    const quotaText = quotaBytes ? formatBytes(quotaBytes) : 'Unlimited';
+
+    let expirationText = 'No expiration';
+    if (clientData.expiration_days) {
+        if (clientData.expiration && clientData.expiration !== '0001-01-01T00:00:00Z') {
+            expirationText = formatTimeRemaining(clientData.expiration);
+        } else if (clientData.first_connected_at) {
+            const exp = new Date(clientData.first_connected_at).getTime() + (clientData.expiration_days * 86400000);
+            expirationText = formatTimeRemaining(exp);
+        } else {
+            expirationText = `${clientData.expiration_days} days`;
+        }
+    }
     const allocatedIps = clientData.allocated_ips || [];
     const allocatedIpsHtml = allocatedIps.map(ip => `<span class=\"inline-block bg-gray-100 dark:bg-dark-700 text-gray-800 dark:text-gray-200 text-xs px-2 py-1 rounded mr-1 mb-1\">${ip}</span>`).join('');
     
@@ -492,7 +504,8 @@ function createClientCard(client) {
     // Data usage display
     const usedQuota = clientData.used_quota || 0;
     const usedQuotaText = formatBytes(usedQuota);
-    const quotaProgress = clientData.quota ? Math.min((usedQuota / (clientData.quota * 1024 * 1024 * 1024)) * 100, 100) : 0;
+    const quotaProgress = quotaBytes ? Math.min((usedQuota / quotaBytes) * 100, 100) : 0;
+    const remainingBytes = quotaBytes ? Math.max(quotaBytes - usedQuota, 0) : 0;
     
     // Last seen display
     const lastSeen = clientData.last_handshake ? new Date(clientData.last_handshake) : null;
@@ -526,10 +539,10 @@ function createClientCard(client) {
                     <div class=\"space-y-1\">
                         <div class=\"flex items-center justify-between text-sm\">
                             <span class=\"text-gray-600 dark:text-gray-400\">Data Usage</span>
-                            <span class=\"text-gray-900 dark:text-white font-medium\">${usedQuotaText}</span>
+                            <span class=\"text-gray-900 dark:text-white font-medium\">${clientData.quota ? `${usedQuotaText} / ${quotaText}` : usedQuotaText}</span>
                         </div>
                         ${clientData.quota ? `<div class=\"w-full bg-gray-200 dark:bg-dark-600 rounded-full h-2\"><div class=\"bg-primary-500 h-2 rounded-full transition-all duration-300\" style=\"width: ${quotaProgress}%\"></div></div>` : ''}
-                        ${clientData.quota ? `<div class=\"flex justify-between text-xs text-gray-500 dark:text-gray-400\"><span>${quotaText}</span><span>${Math.round(quotaProgress)}%</span></div>` : ''}
+                        ${clientData.quota ? `<div class=\"flex justify-between text-xs text-gray-500 dark:text-gray-400\"><span>Remaining ${formatBytes(remainingBytes)}</span><span>${Math.round(quotaProgress)}%</span></div>` : ''}
                     </div>
                     
                     <!-- Last Seen -->
@@ -569,7 +582,7 @@ function toggleAutoRefresh() {
 
 // Utility functions
         function formatBytes(bytes) {
-            if (bytes === 0) return '0 B';
+            if (!bytes || isNaN(bytes) || bytes <= 0) return '0 B';
             const k = 1024;
             const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
             const i = Math.floor(Math.log(bytes) / Math.log(k));
@@ -589,6 +602,18 @@ function formatLastSeen(date) {
     if (days < 7) return `${days} day${days > 1 ? 's' : ''} ago`;
     
     return date.toLocaleDateString() + ' ' + date.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
+}
+
+function formatTimeRemaining(expiration) {
+    if (!expiration) return 'No expiration';
+    const expDate = new Date(expiration);
+    if (isNaN(expDate.getTime())) return 'No expiration';
+    const now = new Date();
+    if (expDate <= now) return 'Expired';
+    const diff = expDate - now;
+    const days = Math.floor(diff / 86400000);
+    const hours = Math.floor((diff % 86400000) / 3600000);
+    return `${days}d ${hours}h left`;
 }
 
 function debounce(func, wait) {


### PR DESCRIPTION
## Summary
- update client card to show remaining data and quota progress
- show expiration countdown after first connection

## Testing
- `go test ./...` *(fails: downloading dependencies forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686fbfbfe6ac8327a69c8206f4a3bb66