### PR TITLE
Implement tunnel service & health monitoring

### DIFF
--- a/docs/TROUBLESHOOT.md
+++ b/docs/TROUBLESHOOT.md
@@ -1,0 +1,15 @@
+# Troubleshooting
+
+## No packets passing
+If your clients connect but cannot access the Internet, make sure NAT rules are present and the MTU is set correctly.
+
+1. Check that iptables has a MASQUERADE rule for your tunnel subnet:
+   ```bash
+   iptables -t nat -A POSTROUTING -s <WG_SUBNET> -o <OUT_IFACE> -j MASQUERADE
+   ```
+2. Enable IP forwarding:
+   ```bash
+   sysctl -w net.ipv4.ip_forward=1
+   sysctl -w net.ipv6.conf.all.forwarding=1
+   ```
+3. On clients use MTU 1420 or lower to avoid fragmentation issues.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,8 @@ require (
 	github.com/labstack/echo-contrib v0.15.0
 	github.com/labstack/echo/v4 v4.11.4
 	github.com/labstack/gommon v0.4.2
-	github.com/rs/xid v1.5.0
+        github.com/rs/xid v1.5.0
+        github.com/gorilla/websocket v1.5.0
 	github.com/sabhiram/go-wol v0.0.0-20211224004021-c83b0c2f887d
 	github.com/sdomino/scribble v0.0.0-20230717151034-b95d4df19aa8
 	github.com/sendgrid/sendgrid-go v3.14.0+incompatible

--- a/handler/health_stream.go
+++ b/handler/health_stream.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+
+	"github.com/MmadF14/vwireguard/monitor"
+)
+
+var upgrader = websocket.Upgrader{}
+
+func TunnelHealthStream() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		conn, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
+		if err != nil {
+			return err
+		}
+		ch := monitor.Subscribe()
+		defer monitor.Unsubscribe(ch)
+		for {
+			select {
+			case up := <-ch:
+				if err := conn.WriteJSON(up); err != nil {
+					return nil
+				}
+			default:
+				if _, _, err := conn.NextReader(); err != nil {
+					return nil
+				}
+			}
+		}
+	}
+}

--- a/handler/routes_tunnel.go
+++ b/handler/routes_tunnel.go
@@ -481,29 +481,9 @@ func StartTunnel(db store.IStore) echo.HandlerFunc {
 			return c.JSON(http.StatusBadRequest, jsonHTTPResponse{false, "Tunnel is disabled"})
 		}
 
-		// Implement actual tunnel starting logic based on type
-		switch tunnel.Type {
-		case model.TunnelTypeWireGuardToWireGuard:
-			if err := startWireGuardTunnel(tunnel); err != nil {
-				log.Printf("Failed to start WireGuard tunnel: %v", err)
-				return c.JSON(http.StatusInternalServerError, jsonHTTPResponse{false, "Failed to start WireGuard tunnel: " + err.Error()})
-			}
-		case model.TunnelTypeWireGuardToV2ray:
-			if err := startV2rayTunnel(tunnel); err != nil {
-				log.Printf("Failed to start V2Ray tunnel: %v", err)
-				return c.JSON(http.StatusInternalServerError, jsonHTTPResponse{false, "Failed to start V2Ray tunnel: " + err.Error()})
-			}
-		default:
-			log.Printf("Tunnel type %s not implemented yet", tunnel.Type)
-			return c.JSON(http.StatusNotImplemented, jsonHTTPResponse{false, fmt.Sprintf("Tunnel type %s not implemented yet", tunnel.Type)})
+		if err := service.StartTunnel(db, tunnelID); err != nil {
+			return c.JSON(http.StatusInternalServerError, jsonHTTPResponse{false, err.Error()})
 		}
-
-		// Update status
-		err = db.UpdateTunnelStatus(tunnelID, model.TunnelStatusActive)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, jsonHTTPResponse{false, fmt.Sprintf("Failed to update tunnel status: %v", err)})
-		}
-
 		return c.JSON(http.StatusOK, jsonHTTPResponse{true, "Tunnel started successfully"})
 	}
 }
@@ -519,29 +499,9 @@ func StopTunnel(db store.IStore) echo.HandlerFunc {
 			return c.JSON(http.StatusNotFound, jsonHTTPResponse{false, "Tunnel not found"})
 		}
 
-		// Implement actual tunnel stopping logic based on type
-		switch tunnel.Type {
-		case model.TunnelTypeWireGuardToWireGuard:
-			if err := stopWireGuardTunnel(tunnel); err != nil {
-				log.Printf("Failed to stop WireGuard tunnel: %v", err)
-				return c.JSON(http.StatusInternalServerError, jsonHTTPResponse{false, "Failed to stop WireGuard tunnel: " + err.Error()})
-			}
-		case model.TunnelTypeWireGuardToV2ray:
-			if err := stopV2rayTunnel(tunnel); err != nil {
-				log.Printf("Failed to stop V2Ray tunnel: %v", err)
-				return c.JSON(http.StatusInternalServerError, jsonHTTPResponse{false, "Failed to stop V2Ray tunnel: " + err.Error()})
-			}
-		default:
-			log.Printf("Tunnel type %s not implemented yet", tunnel.Type)
-			return c.JSON(http.StatusNotImplemented, jsonHTTPResponse{false, fmt.Sprintf("Tunnel type %s not implemented yet", tunnel.Type)})
+		if err := service.StopTunnel(db, tunnelID); err != nil {
+			return c.JSON(http.StatusInternalServerError, jsonHTTPResponse{false, err.Error()})
 		}
-
-		// Update status
-		err = db.UpdateTunnelStatus(tunnelID, model.TunnelStatusInactive)
-		if err != nil {
-			return c.JSON(http.StatusInternalServerError, jsonHTTPResponse{false, fmt.Sprintf("Failed to update tunnel status: %v", err)})
-		}
-
 		return c.JSON(http.StatusOK, jsonHTTPResponse{true, "Tunnel stopped successfully"})
 	}
 }

--- a/integration/ping_test.sh
+++ b/integration/ping_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Simple integration test for tunnel routing
+set -e
+ID=$1
+wg-quick up client.conf
+curl -m 5 -s -o /dev/null https://8.8.8.8 && echo "OK" || echo "FAIL"
+wg-quick down client.conf

--- a/model/tunnel.go
+++ b/model/tunnel.go
@@ -34,6 +34,7 @@ type Tunnel struct {
 	Name        string       `json:"name"`
 	Type        TunnelType   `json:"type"`
 	Status      TunnelStatus `json:"status"`
+	StatusColor string       `json:"status_color"`
 	Description string       `json:"description"`
 
 	// Client routing - which clients use this tunnel

--- a/monitor/health.go
+++ b/monitor/health.go
@@ -1,0 +1,92 @@
+package monitor
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MmadF14/vwireguard/model"
+	"github.com/MmadF14/vwireguard/store"
+)
+
+type Update struct {
+	ID    string `json:"id"`
+	Color string `json:"color"`
+}
+
+var (
+	subsMu      sync.Mutex
+	subscribers = map[chan Update]struct{}{}
+)
+
+func Subscribe() chan Update {
+	ch := make(chan Update, 1)
+	subsMu.Lock()
+	subscribers[ch] = struct{}{}
+	subsMu.Unlock()
+	return ch
+}
+
+func Unsubscribe(ch chan Update) {
+	subsMu.Lock()
+	delete(subscribers, ch)
+	close(ch)
+	subsMu.Unlock()
+}
+
+func publish(u Update) {
+	subsMu.Lock()
+	for ch := range subscribers {
+		select {
+		case ch <- u:
+		default:
+		}
+	}
+	subsMu.Unlock()
+}
+
+func Start(db store.IStore) {
+	go func() {
+		for {
+			tunnels, err := db.GetTunnels()
+			if err == nil {
+				for _, t := range tunnels {
+					color := "gray"
+					if t.Status == model.TunnelStatusActive {
+						if t.Type == model.TunnelTypeWireGuardToWireGuard {
+							iface := "wg" + t.ID[len(t.ID)-3:]
+							out, err := exec.Command("wg", "show", iface, "latest-handshakes").Output()
+							if err == nil && len(out) > 0 {
+								parts := strings.Fields(string(out))
+								if len(parts) >= 2 {
+									ts, _ := time.ParseDuration(parts[1] + "ms")
+									if ts.Seconds() <= 90 {
+										color = "green"
+									} else {
+										color = "red"
+									}
+								}
+							}
+						} else if t.WGConfig != nil {
+							ip := t.WGConfig.TunnelIP
+							if ip != "" {
+								if err := exec.Command("ping", "-c", "1", "-W", "2", "-I", ip, "1.1.1.1").Run(); err == nil {
+									color = "green"
+								} else {
+									color = "red"
+								}
+							}
+						}
+					}
+					if t.StatusColor != color {
+						t.StatusColor = color
+						db.SaveTunnel(t)
+						publish(Update{ID: t.ID, Color: color})
+					}
+				}
+			}
+			time.Sleep(30 * time.Second)
+		}
+	}()
+}

--- a/router/tunnel_router.go
+++ b/router/tunnel_router.go
@@ -14,4 +14,7 @@ func RegisterTunnelRoutes(g *echo.Group, db store.IStore) {
 	g.PUT("/v2ray/:id", handler.UpdateV2rayTunnel(db), handler.ValidSession, handler.ContentTypeJson)
 	g.POST("/:id/enable", handler.EnableTunnel(db), handler.ValidSession, handler.ContentTypeJson)
 	g.POST("/:id/disable", handler.DisableTunnel(db), handler.ValidSession, handler.ContentTypeJson)
+	g.PUT("/:id/start", handler.StartTunnel(db), handler.ValidSession, handler.ContentTypeJson)
+	g.PUT("/:id/stop", handler.StopTunnel(db), handler.ValidSession, handler.ContentTypeJson)
+	g.GET("/health/stream", handler.TunnelHealthStream(), handler.ValidSession)
 }

--- a/service/tunnel_service.go
+++ b/service/tunnel_service.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/MmadF14/vwireguard/model"
+	"github.com/MmadF14/vwireguard/store"
 )
 
 // GenerateXrayConfig builds an Xray config for WireGuard->V2Ray tunnels
@@ -171,10 +173,77 @@ ExecStart=/usr/local/bin/xray -c /etc/vwireguard/tunnels/%%i.json
 Restart=on-failure
 [Install]
 WantedBy=multi-user.target
-`, tunnel.ID, tunnel.ID)
+`, tunnel.ID)
 	if err := os.WriteFile(servicePath, []byte(serviceContent), 0644); err != nil {
 		return err
 	}
 	exec.Command("systemctl", "daemon-reload").Run()
-	return exec.Command("systemctl", "enable", "--now", fmt.Sprintf("vwireguard-tunnel-%s.service", tunnel.ID)).Run()
+	if err := exec.Command("systemctl", "enable", "--now", fmt.Sprintf("vwireguard-tunnel-%s.service", tunnel.ID)).Run(); err != nil {
+		return err
+	}
+
+	// Setup NAT rules for the tunnel network
+	if tunnel.WGConfig != nil {
+		subnet := tunnel.WGConfig.TunnelIP + "/24"
+		outIface := "eth0"
+		if tunnel.V2rayConfig != nil {
+			remote := tunnel.V2rayConfig.RemoteAddress
+			if idx := strings.Index(remote, ":"); idx > 0 {
+				remote = remote[:idx]
+			}
+			if routeOut, err := exec.Command("sh", "-c", fmt.Sprintf("ip route get %s | awk '{for(i=1;i<NF;i++){if($i==\"dev\"){print $(i+1);exit}}}'", remote)).Output(); err == nil {
+				outIface = strings.TrimSpace(string(routeOut))
+			}
+		}
+		exec.Command("sysctl", "-w", "net.ipv4.ip_forward=1").Run()
+		exec.Command("sysctl", "-w", "net.ipv6.conf.all.forwarding=1").Run()
+		exec.Command("iptables", "-t", "nat", "-A", "POSTROUTING", "-s", subnet, "-o", outIface, "-j", "MASQUERADE").Run()
+	}
+	return nil
+}
+
+// StartTunnel starts the systemd service for the given tunnel ID. If the tunnel
+// has RouteAll enabled, any other active RouteAll tunnels will be stopped first.
+func StartTunnel(db store.IStore, id string) error {
+	tunnel, err := db.GetTunnelByID(id)
+	if err != nil {
+		return err
+	}
+
+	if tunnel.RouteAll {
+		tunnels, err := db.GetTunnels()
+		if err == nil {
+			for _, t := range tunnels {
+				if t.ID != tunnel.ID && t.RouteAll && t.Status == model.TunnelStatusActive {
+					exec.Command("systemctl", "stop", fmt.Sprintf("vwireguard-tunnel-%s.service", t.ID)).Run()
+					t.Status = model.TunnelStatusInactive
+					db.SaveTunnel(t)
+				}
+			}
+		}
+	}
+
+	if os.Getenv("VWIREGUARD_TEST") != "1" {
+		if err := exec.Command("systemctl", "start", fmt.Sprintf("vwireguard-tunnel-%s.service", id)).Run(); err != nil {
+			return err
+		}
+	}
+
+	tunnel.Status = model.TunnelStatusActive
+	return db.SaveTunnel(tunnel)
+}
+
+// StopTunnel stops the systemd service for the given tunnel ID and marks it inactive.
+func StopTunnel(db store.IStore, id string) error {
+	tunnel, err := db.GetTunnelByID(id)
+	if err != nil {
+		return err
+	}
+
+	if os.Getenv("VWIREGUARD_TEST") != "1" {
+		exec.Command("systemctl", "stop", fmt.Sprintf("vwireguard-tunnel-%s.service", id)).Run()
+	}
+
+	tunnel.Status = model.TunnelStatusInactive
+	return db.SaveTunnel(tunnel)
 }

--- a/static/js/tunnel-list.js
+++ b/static/js/tunnel-list.js
@@ -1,0 +1,20 @@
+window.tunnelList = function(tunnels) {
+    return {
+        tunnels: tunnels,
+        init() {
+            const ws = new WebSocket(`${window.basePath}/api/tunnels/health/stream`);
+            ws.onmessage = (ev) => {
+                const data = JSON.parse(ev.data);
+                if(this.tunnels[data.id]) {
+                    this.tunnels[data.id].status = data.color;
+                }
+            };
+        },
+        async toggle(id) {
+            const t = this.tunnels[id];
+            const action = t.status === 'inactive' ? 'start' : 'stop';
+            t.status = action === 'start' ? 'green' : 'inactive';
+            await fetch(`${window.basePath}/api/tunnels/${id}/${action}`, {method:'PUT'});
+        }
+    };
+}

--- a/tests/tunnel_handler_test.go
+++ b/tests/tunnel_handler_test.go
@@ -1,0 +1,95 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/MmadF14/vwireguard/handler"
+	"github.com/MmadF14/vwireguard/model"
+	"github.com/MmadF14/vwireguard/store"
+)
+
+type memStore struct{ tunnels map[string]model.Tunnel }
+
+func (m *memStore) Init() error                              { return nil }
+func (m *memStore) GetUsers() ([]model.User, error)          { return nil, nil }
+func (m *memStore) GetUserByName(string) (model.User, error) { return model.User{}, nil }
+func (m *memStore) SaveUser(model.User) error                { return nil }
+func (m *memStore) DeleteUser(string) error                  { return nil }
+func (m *memStore) GetGlobalSettings() (model.GlobalSetting, error) {
+	return model.GlobalSetting{}, nil
+}
+func (m *memStore) GetServer() (model.Server, error)            { return model.Server{}, nil }
+func (m *memStore) GetClients(bool) ([]model.ClientData, error) { return nil, nil }
+func (m *memStore) GetClientByID(string, model.QRCodeSettings) (model.ClientData, error) {
+	return model.ClientData{}, nil
+}
+func (m *memStore) SaveClient(model.Client) error                         { return nil }
+func (m *memStore) DeleteClient(string) error                             { return nil }
+func (m *memStore) SaveServerInterface(model.ServerInterface) error       { return nil }
+func (m *memStore) SaveServerKeyPair(model.ServerKeypair) error           { return nil }
+func (m *memStore) SaveGlobalSettings(model.GlobalSetting) error          { return nil }
+func (m *memStore) GetWakeOnLanHosts() ([]model.WakeOnLanHost, error)     { return nil, nil }
+func (m *memStore) GetWakeOnLanHost(string) (*model.WakeOnLanHost, error) { return nil, nil }
+func (m *memStore) DeleteWakeOnHostLanHost(string) error                  { return nil }
+func (m *memStore) SaveWakeOnLanHost(model.WakeOnLanHost) error           { return nil }
+func (m *memStore) DeleteWakeOnHost(model.WakeOnLanHost) error            { return nil }
+func (m *memStore) GetPath() string                                       { return "" }
+func (m *memStore) SaveHashes(model.ClientServerHashes) error             { return nil }
+func (m *memStore) GetHashes() (model.ClientServerHashes, error) {
+	return model.ClientServerHashes{}, nil
+}
+func (m *memStore) GetTunnels() ([]model.Tunnel, error) {
+	ts := []model.Tunnel{}
+	for _, t := range m.tunnels {
+		ts = append(ts, t)
+	}
+	return ts, nil
+}
+func (m *memStore) GetTunnelByID(id string) (model.Tunnel, error) { return m.tunnels[id], nil }
+func (m *memStore) SaveTunnel(t model.Tunnel) error               { m.tunnels[t.ID] = t; return nil }
+func (m *memStore) DeleteTunnel(string) error                     { return nil }
+func (m *memStore) UpdateTunnelStatus(id string, s model.TunnelStatus) error {
+	t := m.tunnels[id]
+	t.Status = s
+	m.tunnels[id] = t
+	return nil
+}
+func (m *memStore) UpdateTunnelStats(string, int64, int64) error { return nil }
+
+func TestRouteAllConflict(t *testing.T) {
+	os.Setenv("VWIREGUARD_TEST", "1")
+	db := &memStore{tunnels: map[string]model.Tunnel{
+		"a": {ID: "a", RouteAll: true, Status: model.TunnelStatusInactive, Enabled: true},
+		"b": {ID: "b", RouteAll: true, Status: model.TunnelStatusInactive, Enabled: true},
+	}}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/:id/start")
+	c.SetParamNames("id")
+	c.SetParamValues("a")
+	if err := handler.StartTunnel(db)(c); err != nil {
+		t.Fatal(err)
+	}
+	if db.tunnels["a"].Status != model.TunnelStatusActive {
+		t.Fatalf("first tunnel not active")
+	}
+	req2 := httptest.NewRequest(http.MethodPut, "/", nil)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetPath("/:id/start")
+	c2.SetParamNames("id")
+	c2.SetParamValues("b")
+	if err := handler.StartTunnel(db)(c2); err != nil {
+		t.Fatal(err)
+	}
+	if db.tunnels["a"].Status != model.TunnelStatusInactive || db.tunnels["b"].Status != model.TunnelStatusActive {
+		t.Fatalf("route-all not switched")
+	}
+}


### PR DESCRIPTION
## Summary
- add StartTunnel/StopTunnel logic with NAT setup
- broadcast health over websocket and client script
- update routes for tunnel start/stop and health stream
- record status color in tunnel model
- integration ping test script and handler unit test
- troubleshooting notes on packet issues

## Testing
- `go mod tidy` *(fails: proxy access blocked)*
- `go test ./...` *(fails: proxy access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_6877b8dba1008327bb05925024a85257