### PR TITLE
Remove Bootstrap remnants and hide debug logs

### DIFF
--- a/static/dist/js/custom.js
+++ b/static/dist/js/custom.js
@@ -104,7 +104,7 @@ function addGlobalStyle(css, id) {
 
 // Global function برای Apply Config - بدون هیچ dependency
 window.applyConfig = function() {
-    console.log("Apply Config called directly");
+    if (window.DEBUG) console.log("Apply Config called directly");
     
     if (confirm("Do you want to write config file and restart WireGuard server?")) {
         const xhr = new XMLHttpRequest();
@@ -113,7 +113,7 @@ window.applyConfig = function() {
         
         xhr.onreadystatechange = function() {
             if (xhr.readyState === 4) {
-                console.log("Apply config response:", xhr.status, xhr.responseText);
+                if (window.DEBUG) console.log("Apply config response:", xhr.status, xhr.responseText);
                 if (xhr.status === 200) {
                     alert('Applied config successfully');
                     if (typeof location !== 'undefined') {
@@ -141,7 +141,7 @@ function forceShowApplyConfig() {
     const btn = document.getElementById("apply-config-button");
     if (btn) {
         btn.style.cssText = "margin-left: 0.5em; display: inline-block !important; visibility: visible !important; opacity: 1 !important;";
-        console.log("Apply Config FORCED to show");
+        if (window.DEBUG) console.log("Apply Config FORCED to show");
         return true;
     }
     console.error("Apply Config NOT FOUND!");
@@ -172,7 +172,7 @@ function protectApplyConfigButton() {
                 if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
                     const style = applyBtn.getAttribute('style') || '';
                     if (style.includes('display: none') || style.includes('visibility: hidden')) {
-                        console.log("Apply Config button under attack! Protecting...");
+                        if (window.DEBUG) console.log("Apply Config button under attack! Protecting...");
                         forceShowApplyConfig();
                     }
                 }
@@ -184,7 +184,7 @@ function protectApplyConfigButton() {
             attributeFilter: ['style', 'class']
         });
         
-        console.log("Apply Config button is now protected!");
+        if (window.DEBUG) console.log("Apply Config button is now protected!");
     }
 }
 
@@ -198,9 +198,9 @@ function updateApplyConfigVisibility() {
                 'display': 'inline-block !important',
                 'visibility': 'visible !important'
             });
-            console.log("Apply Config button forced to show");
+            if (window.DEBUG) console.log("Apply Config button forced to show");
         } else {
-            console.warn("Apply Config button not found in DOM");
+            if (window.DEBUG) console.warn("Apply Config button not found in DOM");
         }
     });
 }
@@ -255,7 +255,7 @@ function updateStatusIndicators() {
 
 // Initialize all functionality
 document.addEventListener('DOMContentLoaded', () => {
-    console.log("DOM loaded - ensuring Apply Config is visible");
+    if (window.DEBUG) console.log("DOM loaded - ensuring Apply Config is visible");
     
     // اطمینان از نمایش Apply Config
     ensureApplyConfigVisible();
@@ -331,7 +331,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Apply config confirm button event - ساده شده
     $("#apply_config_confirm").click(function () {
-        console.log("Apply config clicked");
+        if (window.DEBUG) console.log("Apply config clicked");
         $.ajax({
             cache: false,
             method: 'POST',
@@ -339,7 +339,7 @@ document.addEventListener('DOMContentLoaded', () => {
             dataType: 'json',
             contentType: "application/json",
             success: function(data) {
-                console.log("Apply config success");
+                if (window.DEBUG) console.log("Apply config success");
                 $("#modal_apply_config").modal('hide');
                 if (typeof showNotification === 'function') {
                     showNotification('Applied config successfully', 'success');
@@ -380,13 +380,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // مطمئن شدن که Apply Config button همیشه نمایش داده میشه
 window.onload = function() {
-    console.log("Window loaded - forcing Apply Config");
+    if (window.DEBUG) console.log("Window loaded - forcing Apply Config");
     ensureApplyConfigVisible();
 };
 
 // هر بار که صفحه focus میشه، دوباره چک کن
 window.onfocus = function() {
-    console.log("Window focused - forcing Apply Config");
+    if (window.DEBUG) console.log("Window focused - forcing Apply Config");
     forceShowApplyConfig();
 };
 

--- a/static/dist/js/language.js
+++ b/static/dist/js/language.js
@@ -35,10 +35,10 @@ class LanguageManager {
     }
 
     translatePage() {
-        console.log('Translating page to:', this.currentLang);
+        if (window.DEBUG) console.log('Translating page to:', this.currentLang);
         // First, translate all elements with data-translate attribute
         const elementsToTranslate = document.querySelectorAll('[data-translate]');
-        console.log('Found', elementsToTranslate.length, 'elements to translate');
+        if (window.DEBUG) console.log('Found', elementsToTranslate.length, 'elements to translate');
         
         elementsToTranslate.forEach(element => {
             const key = element.getAttribute('data-translate');

--- a/static/dist/js/theme-manager.js
+++ b/static/dist/js/theme-manager.js
@@ -385,5 +385,5 @@ document.addEventListener('DOMContentLoaded', () => {
         card.classList.add('animate-fade-in');
     });
     
-    console.log('Theme and Language Manager initialized');
+    if (window.DEBUG) console.log('Theme and Language Manager initialized');
 }); 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1240,7 +1240,7 @@
                     if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
                         const display = newClientModal.style.display;
                         if (display === 'block' || display === 'flex') {
-                            console.log('Modal opened, initializing form');
+                            if (window.DEBUG) console.log('Modal opened, initializing form');
                             initializeNewClientForm();
                         }
                     }
@@ -1257,7 +1257,7 @@
                     if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
                         const display = editClientModal.style.display;
                         if (display === 'block' || display === 'flex') {
-                            console.log('Edit modal opened');
+                            if (window.DEBUG) console.log('Edit modal opened');
                         }
                     }
                 });
@@ -1266,7 +1266,7 @@
         }
             
             // Initialize any additional interactive elements
-            console.log('vWireguard Dashboard initialized');
+            if (window.DEBUG) console.log('vWireguard Dashboard initialized');
     });
         
         // New Client Form Functionality
@@ -1293,7 +1293,7 @@
                 newClientForm.addEventListener('submit', function(e) {
                     e.preventDefault();
                     
-                    console.log('New client form submitted');
+                    if (window.DEBUG) console.log('New client form submitted');
                     
                     const formData = new FormData(this);
                     
@@ -1338,7 +1338,7 @@
                         enabled: document.getElementById('enabled').checked,
                     };
                     
-                    console.log('Client data to send:', clientData);
+                    if (window.DEBUG) console.log('Client data to send:', clientData);
                     
                     // Validate required fields
                     if (!clientData.name.trim()) {
@@ -1354,15 +1354,15 @@
                         body: JSON.stringify(clientData),
                     })
                     .then(response => {
-                        console.log('Response status:', response.status);
-                        console.log('Response headers:', response.headers);
+                        if (window.DEBUG) console.log('Response status:', response.status);
+                        if (window.DEBUG) console.log('Response headers:', response.headers);
                         if (!response.ok) {
                             throw new Error(`HTTP error! status: ${response.status}`);
                         }
                         return response.json();
                     })
                     .then(data => {
-                        console.log('Response data:', data);
+                        if (window.DEBUG) console.log('Response data:', data);
                         if (data.success) {
                             document.getElementById('modal_new_client').style.display = 'none';
                             newClientForm.reset();
@@ -1548,7 +1548,7 @@
         
         // Utility functions
         function showSuccess(message) {
-            console.log('Success:', message);
+            if (window.DEBUG) console.log('Success:', message);
             alert(message);
         }
         
@@ -1577,7 +1577,7 @@
                 enabled: true,
             };
             
-            console.log('Testing API with data:', testData);
+            if (window.DEBUG) console.log('Testing API with data:', testData);
             
             fetch('{{.basePath}}/new-client', {
                 method: 'POST',
@@ -1587,11 +1587,11 @@
                 body: JSON.stringify(testData),
             })
             .then(response => {
-                console.log('Test response status:', response.status);
+                if (window.DEBUG) console.log('Test response status:', response.status);
                 return response.json();
             })
             .then(data => {
-                console.log('Test response data:', data);
+                if (window.DEBUG) console.log('Test response data:', data);
                 if (data.success) {
                     showSuccess('Test client created successfully');
                 } else {

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -15,7 +15,7 @@
 
 {{define "page_content"}}
 <section class="content">
-    <div class="container-fluid">
+    <div class="mx-auto px-4">
         <!-- <h5 class="mt-4 mb-2">Wireguard Clients</h5> -->
         <div class="mb-4 flex justify-end items-center space-x-4 rtl:space-x-reverse">
             <label class="inline-flex items-center cursor-pointer">
@@ -714,8 +714,8 @@ window.applyConfig = function() {
 
 // Make functions globally available
 window.editClient = function(clientId) {
-    console.log('editClient called with', clientId); // Debug log
-    console.log('Available clients:', clients); // Debug log
+    if (window.DEBUG) console.log('editClient called with', clientId); // Debug log
+    if (window.DEBUG) console.log('Available clients:', clients); // Debug log
     
     const client = clients.find(c => {
         const clientData = c.Client || c;
@@ -774,13 +774,13 @@ window.editClient = function(clientId) {
     
     // Show the modal
     const modal = document.getElementById('modal_edit_client');
-    console.log('Modal element found:', modal); // Debug log
+    if (window.DEBUG) console.log('Modal element found:', modal); // Debug log
     if (modal) {
-        console.log('Modal classes before:', modal.classList.toString()); // Debug log
+        if (window.DEBUG) console.log('Modal classes before:', modal.classList.toString()); // Debug log
         modal.style.display = 'flex';
         modal.classList.remove('hidden');
-        console.log('Modal classes after:', modal.classList.toString()); // Debug log
-        console.log('Modal style display:', modal.style.display); // Debug log
+        if (window.DEBUG) console.log('Modal classes after:', modal.classList.toString()); // Debug log
+        if (window.DEBUG) console.log('Modal style display:', modal.style.display); // Debug log
     } else {
         console.error('modal_edit_client not found in DOM');
         showError('Edit modal not found!');

--- a/templates/server.html
+++ b/templates/server.html
@@ -338,12 +338,12 @@ document.addEventListener('keydown', function(e) {
 {{define "bottom_js"}}
 <script>
     function submitServerInterfaceSetting() {
-        console.log('submitServerInterfaceSetting called');
+        if (window.DEBUG) console.log('submitServerInterfaceSetting called');
         
         // Show loading state
         const submitBtn = $('#frm_server_interface button[type="submit"]');
         const originalText = submitBtn.html();
-        console.log('Original button text:', originalText);
+        if (window.DEBUG) console.log('Original button text:', originalText);
         
         submitBtn.prop('disabled', true);
         submitBtn.html('<i class="fas fa-spinner fa-spin"></i> <span data-translate="Processing...">Processing...</span>');
@@ -368,11 +368,11 @@ document.addEventListener('keydown', function(e) {
         const final_check_interval = isNaN(check_interval) ? 1 : check_interval;
         const data = {"addresses": addresses, "listen_port": listen_port, "post_up": post_up, "pre_down": pre_down, "post_down": post_down, "check_interval": final_check_interval};
 
-        console.log('Submitting server interface data:', data);
-        console.log('Check interval raw value:', check_interval_val);
-        console.log('Check interval parsed:', check_interval);
-        console.log('Check interval is NaN?', isNaN(check_interval));
-        console.log('Final check interval:', final_check_interval);
+        if (window.DEBUG) console.log('Submitting server interface data:', data);
+        if (window.DEBUG) console.log('Check interval raw value:', check_interval_val);
+        if (window.DEBUG) console.log('Check interval parsed:', check_interval);
+        if (window.DEBUG) console.log('Check interval is NaN?', isNaN(check_interval));
+        if (window.DEBUG) console.log('Final check interval:', final_check_interval);
 
         $.ajax({
             cache: false,
@@ -382,7 +382,7 @@ document.addEventListener('keydown', function(e) {
             contentType: "application/json",
             data: JSON.stringify(data),
             success: function(response) {
-                console.log('Server interface updated successfully:', response);
+                if (window.DEBUG) console.log('Server interface updated successfully:', response);
                 // Reset button state first
                 submitBtn.prop('disabled', false);
                 submitBtn.html('<i class="fas fa-save mr-2 rtl:mr-0 rtl:ml-2"></i><span data-translate="Save">Save</span>');
@@ -403,7 +403,7 @@ document.addEventListener('keydown', function(e) {
                     }
                 } else {
                     // Show success message
-                    console.log('Showing success message');
+                    if (window.DEBUG) console.log('Showing success message');
                     if (typeof toastr !== 'undefined') {
                         const successMessage = (window.langManager && window.langManager.translate) ? 
                             window.langManager.translate('Updated Wireguard server interface addresses successfully') : 
@@ -450,7 +450,7 @@ document.addEventListener('keydown', function(e) {
 <script>
     // Wireguard Interface Addresses tag input
     $(document).ready(function() {
-        console.log('Document ready - initializing tags input');
+        if (window.DEBUG) console.log('Document ready - initializing tags input');
         
         $("#addresses").tagsInput({
             'width': '100%',
@@ -463,11 +463,11 @@ document.addEventListener('keydown', function(e) {
             'placeholderColor': '#666666'
         });
         
-        console.log('Tags input initialized');
+        if (window.DEBUG) console.log('Tags input initialized');
         
         // Add direct click handler for save button
         $('#frm_server_interface button[type="submit"]').on('click', function(e) {
-            console.log('Save button clicked directly');
+            if (window.DEBUG) console.log('Save button clicked directly');
             e.preventDefault();
             submitServerInterfaceSetting();
             return false;
@@ -482,17 +482,17 @@ document.addEventListener('keydown', function(e) {
 
     // Wireguard Interface Addresses form validation
     $(document).ready(function () {
-        console.log('Setting up form validation for server interface');
+        if (window.DEBUG) console.log('Setting up form validation for server interface');
         
         // Also add a direct submit handler as backup
         $('#frm_server_interface').on('submit', function(e) {
-            console.log('Form submit event triggered');
+            if (window.DEBUG) console.log('Form submit event triggered');
             e.preventDefault();
             if ($(this).valid()) {
-                console.log('Form is valid, calling submitServerInterfaceSetting');
+                if (window.DEBUG) console.log('Form is valid, calling submitServerInterfaceSetting');
                 submitServerInterfaceSetting();
             } else {
-                console.log('Form is not valid');
+                if (window.DEBUG) console.log('Form is not valid');
             }
             return false;
         });

--- a/templates/status.html
+++ b/templates/status.html
@@ -29,7 +29,7 @@ Connected Peers
   }
 </script>
 <section class="content">
-    <div class="container-fluid">
+    <div class="mx-auto px-4">
         {{ if .error }}
         <div class="mb-4 px-4 py-3 text-yellow-800 bg-yellow-50 rounded-xl border border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-200" role="alert">{{.error}}</div>
         {{ end }}

--- a/templates/tunnels.html
+++ b/templates/tunnels.html
@@ -598,28 +598,6 @@
     </div>
 </div>
 
-<!-- Cleanup Modal -->
-<div class="modal fade" id="modal_cleanup_tunnels" role="dialog">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title" data-translate="Cleanup Corrupted Tunnels">Cleanup Corrupted Tunnels</h4>
-                <button type="button" class="close" data-dismiss="modal">
-                    <span>&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <p data-translate="This will remove any corrupted tunnel records that cannot be loaded properly.">This will remove any corrupted tunnel records that cannot be loaded properly.</p>
-                <p><strong data-translate="Warning:">Warning:</strong> <span data-translate="This action cannot be undone!">This action cannot be undone!</span></p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal" data-translate="Cancel">Cancel</button>
-                <button type="button" class="btn btn-warning" onclick="cleanupTunnels()" data-translate="Smart Cleanup">Smart Cleanup</button>
-                <button type="button" class="btn btn-danger" onclick="deleteAllTunnels()" data-translate="Delete All">Delete All</button>
-            </div>
-        </div>
-    </div>
-</div>
 {{end}}
 
 {{define "bottom_js"}}
@@ -821,29 +799,29 @@ function smartTranslateTunnels() {
     // Check if current language is Persian
     const currentLang = localStorage.getItem('language') || 'en';
     if (currentLang !== 'fa') {
-        console.log('Not Persian language, skipping additional translation');
+        if (window.DEBUG) console.log('Not Persian language, skipping additional translation');
         return;
     }
     
-    console.log('Smart translating tunnels page for Persian...');
+    if (window.DEBUG) console.log('Smart translating tunnels page for Persian...');
     
     // First try to use the global translation system
     if (typeof applyTranslations === 'function') {
-        console.log('Using global applyTranslations function');
+        if (window.DEBUG) console.log('Using global applyTranslations function');
         applyTranslations();
     } else if (window.translations && window.translations.fa) {
-        console.log('Using manual translation with window.translations');
+        if (window.DEBUG) console.log('Using manual translation with window.translations');
         // Manual translation fallback
         const faTranslations = window.translations.fa;
         document.querySelectorAll('[data-translate]').forEach(element => {
             const key = element.getAttribute('data-translate');
             if (faTranslations[key]) {
-                console.log('Translating:', key, '->', faTranslations[key]);
+                if (window.DEBUG) console.log('Translating:', key, '->', faTranslations[key]);
                 element.textContent = faTranslations[key];
             }
         });
     } else {
-        console.log('No translation system available, using hardcoded translations');
+        if (window.DEBUG) console.log('No translation system available, using hardcoded translations');
         // Hardcoded translations as last resort
         const hardcodedTranslations = {
             'Tunnels': 'تانل‌ها',
@@ -920,7 +898,7 @@ function smartTranslateTunnels() {
         document.querySelectorAll('[data-translate]').forEach(element => {
             const key = element.getAttribute('data-translate');
             if (hardcodedTranslations[key]) {
-                console.log('Hardcoded translating:', key, '->', hardcodedTranslations[key]);
+                if (window.DEBUG) console.log('Hardcoded translating:', key, '->', hardcodedTranslations[key]);
                 element.textContent = hardcodedTranslations[key];
             }
         });
@@ -943,28 +921,28 @@ function smartTranslateTunnels() {
         }
     });
     
-    console.log('Smart translation completed');
+    if (window.DEBUG) console.log('Smart translation completed');
 }
 
 // Run smart translation when page loads
 document.addEventListener('DOMContentLoaded', function() {
-    console.log('Tunnels page DOM loaded');
+    if (window.DEBUG) console.log('Tunnels page DOM loaded');
     
     // Wait for the main translation system to load first
     setTimeout(function() {
-        console.log('Running translation check...');
-        console.log('Current language:', localStorage.getItem('language'));
-        console.log('langManager exists:', typeof window.langManager);
-        console.log('translatePage exists:', window.langManager && typeof window.langManager.translatePage);
-        console.log('applyTranslations exists:', typeof applyTranslations);
-        console.log('window.translations exists:', typeof window.translations);
+        if (window.DEBUG) console.log('Running translation check...');
+        if (window.DEBUG) console.log('Current language:', localStorage.getItem('language'));
+        if (window.DEBUG) console.log('langManager exists:', typeof window.langManager);
+        if (window.DEBUG) console.log('translatePage exists:', window.langManager && typeof window.langManager.translatePage);
+        if (window.DEBUG) console.log('applyTranslations exists:', typeof applyTranslations);
+        if (window.DEBUG) console.log('window.translations exists:', typeof window.translations);
         
         // Apply main translation system
         if (window.langManager && window.langManager.translatePage) {
-            console.log('Applying main translation system');
+            if (window.DEBUG) console.log('Applying main translation system');
             window.langManager.translatePage();
         } else {
-            console.log('Main translation system not available, trying manual approach');
+            if (window.DEBUG) console.log('Main translation system not available, trying manual approach');
             // Fallback: manually call translation if langManager is not ready
             if (typeof applyTranslations === 'function') {
                 applyTranslations();
@@ -977,7 +955,7 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Also try earlier
     setTimeout(function() {
-        console.log('Early translation attempt...');
+        if (window.DEBUG) console.log('Early translation attempt...');
         smartTranslateTunnels();
     }, 50);
     
@@ -1029,15 +1007,15 @@ $(document).ready(function() {
     startTunnelStatsRefresh();
     
     // Test jQuery and elements
-    console.log('jQuery loaded:', typeof $ !== 'undefined');
-    console.log('tunnel_type element exists:', $('#tunnel_type').length > 0);
-    console.log('wg_config element exists:', $('#wg_config').length > 0);
+    if (window.DEBUG) console.log('jQuery loaded:', typeof $ !== 'undefined');
+    if (window.DEBUG) console.log('tunnel_type element exists:', $('#tunnel_type').length > 0);
+    if (window.DEBUG) console.log('wg_config element exists:', $('#wg_config').length > 0);
 
     // Handle tunnel form submission (create/edit)
     $('#frm_new_tunnel').on('submit', function(e) {
         e.preventDefault();
         
-        console.log('Form submitted!');
+        if (window.DEBUG) console.log('Form submitted!');
         
         const tunnelId = $('#modal_new_tunnel').data('tunnel-id');
         const isEdit = !!tunnelId;
@@ -1051,7 +1029,7 @@ $(document).ready(function() {
             client_ids: []
         };
 
-        console.log('Form data before validation:', formData);
+        if (window.DEBUG) console.log('Form data before validation:', formData);
 
         // Validate required fields
         if (!formData.name) {
@@ -1169,7 +1147,7 @@ $(document).ready(function() {
             };
         }
         
-        console.log('Final form data:', formData);
+        if (window.DEBUG) console.log('Final form data:', formData);
         
         // Determine URL and method based on create/edit mode
         const url = isEdit ? `{{.basePath}}/api/tunnel/${tunnelId}` : '{{.basePath}}/api/tunnel';
@@ -1183,7 +1161,7 @@ $(document).ready(function() {
             data: JSON.stringify(formData)
         })
         .done(function(response) {
-            console.log('API Response:', response);
+            if (window.DEBUG) console.log('API Response:', response);
             if (response.success) {
                 alert(`Tunnel ${action} successfully!`);
                 closeNewTunnelModal();
@@ -1224,7 +1202,7 @@ $(document).ready(function() {
 
 function showTunnelConfig() {
     const tunnelType = $('#tunnel_type').val();
-    console.log('showTunnelConfig called with type:', tunnelType);
+    if (window.DEBUG) console.log('showTunnelConfig called with type:', tunnelType);
     
     // Reset all required attributes first
     $('#wg_remote_endpoint, #wg_remote_public_key, #dokodemo_address, #dokodemo_port, #pf_remote_host, #pf_remote_port, #v2ray_remote_address, #v2ray_remote_port').removeAttr('required');
@@ -1234,22 +1212,22 @@ function showTunnelConfig() {
     
     // Show relevant config section and set required fields
     if (tunnelType === 'wg-to-wg') {
-        console.log('Showing WireGuard config section');
+        if (window.DEBUG) console.log('Showing WireGuard config section');
         $('#wg_config').removeClass('hidden');
         $('#wg_remote_endpoint, #wg_remote_public_key').attr('required', 'required');
         
         // Run translation after showing the config
         setTimeout(smartTranslateTunnels, 100);
     } else if (tunnelType === 'wg-to-dokodemo') {
-        console.log('Showing Dokodemo config section');
+        if (window.DEBUG) console.log('Showing Dokodemo config section');
         $('#dokodemo_config').removeClass('hidden');
         $('#dokodemo_address, #dokodemo_port').attr('required', 'required');
     } else if (tunnelType === 'port-forward') {
-        console.log('Showing Port Forward config section');
+        if (window.DEBUG) console.log('Showing Port Forward config section');
         $('#port_forward_config').removeClass('hidden');
         $('#pf_remote_host, #pf_remote_port').attr('required', 'required');
     } else if (tunnelType === 'wg-to-v2ray') {
-        console.log('Showing V2Ray config section');
+        if (window.DEBUG) console.log('Showing V2Ray config section');
         $('#v2ray_config').removeClass('hidden');
         $('#v2ray_remote_address, #v2ray_remote_port').attr('required', 'required');
         
@@ -1259,7 +1237,7 @@ function showTunnelConfig() {
 }
 
 function generateWireGuardKeys() {
-    console.log('Generating WireGuard keypair...');
+    if (window.DEBUG) console.log('Generating WireGuard keypair...');
     
     // Hide manual key section
     $('#manual_key_section').addClass('hidden');
@@ -1270,7 +1248,7 @@ function generateWireGuardKeys() {
         contentType: 'application/json'
     })
     .done(function(response) {
-        console.log('Keypair response:', response);
+        if (window.DEBUG) console.log('Keypair response:', response);
         if (response.success) {
             // Store the private key (will be used when creating tunnel)
             $('#wg_config').data('private-key', response.private_key);
@@ -1301,7 +1279,7 @@ function generateWireGuardKeys() {
 }
 
 function showManualKeyEntry() {
-    console.log('Showing manual key entry...');
+    if (window.DEBUG) console.log('Showing manual key entry...');
     
     // Remove any existing alerts
     $('#wg_config .alert').remove();
@@ -1420,7 +1398,7 @@ function generatePublicKeyFromPrivate() {
         return;
     }
     
-    console.log('Generating public key from private key:', privateKey);
+    if (window.DEBUG) console.log('Generating public key from private key:', privateKey);
     
     $.ajax({
         url: '{{.basePath}}/api/tunnel/generate-keypair',
@@ -1431,7 +1409,7 @@ function generatePublicKeyFromPrivate() {
         })
     })
     .done(function(response) {
-        console.log('Public key response:', response);
+        if (window.DEBUG) console.log('Public key response:', response);
         if (response.success) {
             $('#wg_manual_public_key').val(response.public_key);
             
@@ -1464,7 +1442,7 @@ function generatePublicKeyFromPrivate() {
 }
 
 function generatePreSharedKey() {
-    console.log('Generating PreShared Key...');
+    if (window.DEBUG) console.log('Generating PreShared Key...');
     
     $.ajax({
         url: '{{.basePath}}/api/tunnel/generate-preshared-key',
@@ -1472,7 +1450,7 @@ function generatePreSharedKey() {
         contentType: 'application/json'
     })
     .done(function(response) {
-        console.log('PreShared key response:', response);
+        if (window.DEBUG) console.log('PreShared key response:', response);
         if (response.success) {
             $('#wg_preshared_key').val(response.preshared_key);
         } else {
@@ -1486,20 +1464,20 @@ function generatePreSharedKey() {
 }
 
 function loadClientList() {
-    console.log('Loading client list...');
+    if (window.DEBUG) console.log('Loading client list...');
     $.ajax({
         url: '{{.basePath}}/api/clients',
         method: 'GET'
     })
     .done(function(response) {        
         let clientHtml = '';
-        console.log('Client list response:', response);
+        if (window.DEBUG) console.log('Client list response:', response);
         
         // GetClients API response structure: {success: true, data: [{Client: {...}, QRCode: "..."}, ...]}
         let clientsData = [];
         if (response && response.success && Array.isArray(response.data)) {
             clientsData = response.data;
-            console.log('Found', clientsData.length, 'client data objects');
+            if (window.DEBUG) console.log('Found', clientsData.length, 'client data objects');
         } else {
             console.error('Unexpected API response structure:', response);
             $('#client_list').html('<div class="alert alert-warning">Unexpected API response structure</div>');
@@ -1512,7 +1490,7 @@ function loadClientList() {
         }
         
         clientsData.forEach(function(clientDataObj, index) {
-            console.log('Processing client data object', index, ':', clientDataObj);
+            if (window.DEBUG) console.log('Processing client data object', index, ':', clientDataObj);
             
             // ClientData structure: {Client: {...}, QRCode: "..."}
             // کلیدها با حروف بزرگ هستن: Client نه client
@@ -1532,19 +1510,19 @@ function loadClientList() {
                         </label>
                     </div>
                 `;
-                console.log('Added client:', clientName, 'with ID:', client.id, 'and IPs:', ipStr);
+                if (window.DEBUG) console.log('Added client:', clientName, 'with ID:', client.id, 'and IPs:', ipStr);
             } else {
-                console.warn('Invalid client data in object', index, ':', clientDataObj);
-                console.warn('Client object found:', client);
+                if (window.DEBUG) console.warn('Invalid client data in object', index, ':', clientDataObj);
+                if (window.DEBUG) console.warn('Client object found:', client);
             }
         });
         
         if (clientHtml === '') {
             $('#client_list').html('<div class="alert alert-warning">No valid clients found. Please check if you have created any clients in the <a href="/">Wireguard Clients</a> section.</div>');
-            console.warn('No valid clients processed from', clientsData.length, 'client data objects');
+            if (window.DEBUG) console.warn('No valid clients processed from', clientsData.length, 'client data objects');
         } else {
             $('#client_list').html(clientHtml);
-            console.log('Successfully processed and displayed clients');
+            if (window.DEBUG) console.log('Successfully processed and displayed clients');
         }
     })
     .fail(function(xhr, status, error) {
@@ -1678,7 +1656,7 @@ function deleteTunnel(tunnelId) {
 }
 
 function startTunnel(tunnelId) {
-    console.log('Starting tunnel:', tunnelId);
+    if (window.DEBUG) console.log('Starting tunnel:', tunnelId);
     
     // Disable button and show loading
     const startBtn = event.target;
@@ -1741,7 +1719,7 @@ function startTunnel(tunnelId) {
 window.startTunnel = startTunnel;
 
 function stopTunnel(tunnelId) {
-    console.log('Stopping tunnel:', tunnelId);
+    if (window.DEBUG) console.log('Stopping tunnel:', tunnelId);
     
     // Disable button and show loading
     const stopBtn = event.target;
@@ -1976,7 +1954,7 @@ function refreshTunnelStats(tunnelId) {
                 }
             }
         }
-        console.log('Tunnel stats refreshed for', tunnelId);
+        if (window.DEBUG) console.log('Tunnel stats refreshed for', tunnelId);
     })
     .catch(error => {
         console.error('Failed to refresh tunnel stats:', error);


### PR DESCRIPTION
## Summary
- drop leftover Bootstrap containers
- remove unused cleanup modal
- guard debug `console.log`/`console.warn` with `window.DEBUG`

## Testing
- `npx eslint --fix static/dist/js/custom.js static/dist/js/language.js static/dist/js/theme-manager.js`
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*
- `go vet ./...` *(fails: module download blocked)*
- `go test ./...` *(fails: module download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6877b84f35348327b2f4cf55d5def3c1